### PR TITLE
Task 1421: Prevent Deletion of Feedback Items with upvotes

### DIFF
--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -105,7 +105,6 @@ interface FeedbackItemEllipsisMenuItem {
   workflowPhases: WorkflowPhase[];
   hideMobile?: boolean;
   hideMainItem?: boolean;
-  isDisabled?: boolean;
 }
 
 export default class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemState> {
@@ -138,6 +137,7 @@ export default class FeedbackItem extends React.Component<IFeedbackItemProps, IF
 
   public async componentDidMount() {
     await this.isVoted(this.props.id);
+    await this.setDisabledFeedbackItemDeletion(this.props.boardId, this.props.id);
     if (this.props.groupedItemProps && this.props.groupedItemProps.isMainItem) {
       this.updateFeedbackItemGroupShadowCardHeight();
     }
@@ -256,13 +256,13 @@ export default class FeedbackItem extends React.Component<IFeedbackItemProps, IF
     this.hideRemoveFeedbackItemFromGroupConfirmationDialog();
   }
 
-  private setDisabledFeedbackItemDeletion = (boardId: string, id: string) => {
-    itemDataService.getFeedbackItem(boardId, id).then(feedbackItem => {
-        if (feedbackItem && feedbackItem.upvotes > 0) {
-          this.setState({isDeletionDisabled: true});
-        }
-        this.setState({isDeletionDisabled: false});
-      });
+  private setDisabledFeedbackItemDeletion = async (boardId: string, id: string) => {
+    const feedbackItem = await itemDataService.getFeedbackItem(boardId, id);
+    if (feedbackItem && feedbackItem.upvotes > 0) {
+      this.setState({isDeletionDisabled: true});
+    } else {
+      this.setState({isDeletionDisabled: false});
+    }
   }
 
   private onConfirmDeleteFeedbackItem = async () => {
@@ -868,11 +868,7 @@ export default class FeedbackItem extends React.Component<IFeedbackItemProps, IF
               className: 'retrospectives-dialog-modal',
             }}>
             <DialogFooter>
-              <PrimaryButton
-                onClick={this.onConfirmDeleteFeedbackItem}
-                disabled={this.props.upvotes > 0}
-                title="This feedback item can be deleted if it has zero upvotes."
-                text="Delete" />
+              <PrimaryButton onClick={this.onConfirmDeleteFeedbackItem} text="Delete" />
               <DefaultButton onClick={this.hideDeleteItemConfirmationDialog} text="Cancel" />
             </DialogFooter>
           </Dialog>

--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -258,10 +258,8 @@ export default class FeedbackItem extends React.Component<IFeedbackItemProps, IF
 
   private setDisabledFeedbackItemDeletion = async (boardId: string, id: string) => {
     const feedbackItem = await itemDataService.getFeedbackItem(boardId, id);
-    if (feedbackItem && feedbackItem.upvotes > 0) {
-      this.setState({isDeletionDisabled: true});
-    } else {
-      this.setState({isDeletionDisabled: false});
+    if (feedbackItem) {
+      this.setState({isDeletionDisabled: feedbackItem.upvotes > 0});
     }
   }
 

--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -104,6 +104,7 @@ interface FeedbackItemEllipsisMenuItem {
   workflowPhases: WorkflowPhase[];
   hideMobile?: boolean;
   hideMainItem?: boolean;
+  isDisabled?: boolean;
 }
 
 export default class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemState> {
@@ -350,8 +351,9 @@ export default class FeedbackItem extends React.Component<IFeedbackItemProps, IF
         iconProps: { iconName: 'Delete' },
         onClick: this.deleteFeedbackItem,
         text: 'Delete feedback',
-        title: 'Delete feedback',
+        title: 'Delete feedback (disabled when there are active votes)',
       },
+      isDisabled: this.props.upvotes > 0,
       workflowPhases: [ WorkflowPhase.Collect, WorkflowPhase.Group, WorkflowPhase.Vote, WorkflowPhase.Act ],
     },
     {
@@ -726,7 +728,9 @@ export default class FeedbackItem extends React.Component<IFeedbackItemProps, IF
                         items: this.feedbackItemEllipsisMenuItems
                           .filter((menuItem) => !(isMainItem && menuItem.hideMainItem))
                           .map((menuItem) => {
-                            menuItem.menuItem.disabled = menuItem.workflowPhases.indexOf(this.props.workflowPhase) === -1;
+                            menuItem.menuItem.disabled =
+                              menuItem.workflowPhases.indexOf(this.props.workflowPhase) === -1 ||
+                              menuItem.isDisabled;
                             return menuItem.menuItem;
                           })
                       }}
@@ -745,7 +749,8 @@ export default class FeedbackItem extends React.Component<IFeedbackItemProps, IF
                           .filter((menuItem) => !(isMainItem && menuItem.hideMainItem))
                           .map((menuItem) => {
                             menuItem.menuItem.disabled =
-                              menuItem.workflowPhases.indexOf(this.props.workflowPhase) === -1;
+                              menuItem.workflowPhases.indexOf(this.props.workflowPhase) === -1 ||
+                              menuItem.isDisabled;
 
                             return <ActionButton
                               key={menuItem.menuItem.key}

--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -852,7 +852,11 @@ export default class FeedbackItem extends React.Component<IFeedbackItemProps, IF
               className: 'retrospectives-dialog-modal',
             }}>
             <DialogFooter>
-              <PrimaryButton onClick={this.onConfirmDeleteFeedbackItem} text="Delete" />
+              <PrimaryButton
+                onClick={this.onConfirmDeleteFeedbackItem}
+                disabled={this.props.upvotes > 0}
+                title="This feedback item can be deleted if it has zero upvotes."
+                text="Delete" />
               <DefaultButton onClick={this.hideDeleteItemConfirmationDialog} text="Cancel" />
             </DialogFooter>
           </Dialog>

--- a/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
+++ b/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
@@ -210,7 +210,7 @@ class ItemDataService {
     {
       feedbackItem.timerSecs = 0;
     }
-    else
+    else 
     {
       feedbackItem.timerSecs++;
     }
@@ -328,9 +328,9 @@ class ItemDataService {
    * Add a feedback item as a child feedback item of another feedback item.
    * This method also ensures that
    *   1) an existing parent-child association is removed from the old parent if the childFeedbackItem already had one.
-   *   2) the existing children of the child feedback item (if any) become children of the specified parent
+   *   2) the existing children of the child feedback item (if any) become children of the specified parent 
    *   feedback item as well.
-   *   3) that the child feedback item and the existing children of the child feedback item (if any) are
+   *   3) that the child feedback item and the existing children of the child feedback item (if any) are 
    *   assigned the same columnId as the parent feedback item.
    */
   public addFeedbackItemAsChild = async (boardId: string, parentFeedbackItemId: string, childFeedbackItemId: string):
@@ -344,8 +344,8 @@ class ItemDataService {
     const childFeedbackItem: IFeedbackItemDocument = await this.getFeedbackItem(boardId, childFeedbackItemId);
 
     if (!parentFeedbackItem || !childFeedbackItem) {
-      console.log(`Cannot add child for a non-existent feedback item.
-                Board: ${boardId},
+      console.log(`Cannot add child for a non-existent feedback item. 
+                Board: ${boardId}, 
                 Parent Item: ${parentFeedbackItemId},
                 Child Item: ${childFeedbackItemId}`);
       return undefined;
@@ -429,8 +429,8 @@ class ItemDataService {
     const feedbackItem: IFeedbackItemDocument = await this.getFeedbackItem(boardId, feedbackItemId);
 
     if (!feedbackItem) {
-      console.log(`Cannot move a non-existent feedback item.
-              Board: ${boardId},
+      console.log(`Cannot move a non-existent feedback item. 
+              Board: ${boardId}, 
               Parent Item: ${feedbackItem.parentFeedbackItemId},
               Child Item: ${feedbackItemId}`);
       return undefined;
@@ -441,8 +441,8 @@ class ItemDataService {
     if (feedbackItem.parentFeedbackItemId) {
       const parentFeedbackItem: IFeedbackItemDocument = await this.getFeedbackItem(boardId, feedbackItem.parentFeedbackItemId);
       if (!parentFeedbackItem) {
-        console.log(`The given feedback item has a non-existent parent.
-                Board: ${boardId},
+        console.log(`The given feedback item has a non-existent parent. 
+                Board: ${boardId}, 
                 Parent Item: ${feedbackItem.parentFeedbackItemId},
                 Child Item: ${feedbackItemId}`);
         return undefined;
@@ -470,7 +470,7 @@ class ItemDataService {
 
       const updatedChildFeedbackItemPromises: Promise<IFeedbackItemDocument>[] = childFeedbackItems.map((childFeedbackItem) =>
         this.updateFeedbackItem(boardId, childFeedbackItem));
-
+  
       updatedChildFeedbackItems =
         await Promise.all(updatedChildFeedbackItemPromises).then((promiseResults) => {
           return promiseResults.map((updatedChildFeedbackItem) => updatedChildFeedbackItem)
@@ -576,7 +576,7 @@ class ItemDataService {
    * Checks if the work item exists in VSTS and if not, removes it.
    * This handles the special case for when a work item is deleted in VSTS. Currently, when a work item is updated using the navigation form service
    * there is no way to determine if the item was deleted.
-   * https://github.com/MicrosoftDocs/vsts-docs/issues/1545
+   * https://github.com/MicrosoftDocs/vsts-docs/issues/1545 
    */
   public removeAssociatedItemIfNotExistsInVsts = async (boardId: string, feedbackItemId: string, associatedWorkItemId: number): Promise<IFeedbackItemDocument> => {
     let workItems: WorkItem[];

--- a/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
+++ b/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
@@ -354,7 +354,7 @@ class ItemDataService {
     // The parent feedback item must not be a child of another group.
     if (parentFeedbackItem.parentFeedbackItemId) {
       console.log(`Cannot add child if parent is already a child in another group.
-                Board: ${boardId},
+                Board: ${boardId}, 
                 Parent Item: ${parentFeedbackItemId}`);
       return undefined;
     }

--- a/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
+++ b/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
@@ -89,6 +89,10 @@ class ItemDataService {
     let updatedChildFeedbackItems: IFeedbackItemDocument[] = [];
 
     const feedbackItem: IFeedbackItemDocument = await ExtensionDataService.readDocument<IFeedbackItemDocument>(boardId, feedbackItemId);
+    if(feedbackItem && feedbackItem.upvotes > 0) {
+      console.log(`Cannot delete a feedback item which has upvotes. Board: ${boardId} Item: ${feedbackItemId}`);
+      return undefined;
+    }
 
     if (feedbackItem.parentFeedbackItemId) {
       const parentFeedbackItem: IFeedbackItemDocument =
@@ -206,7 +210,7 @@ class ItemDataService {
     {
       feedbackItem.timerSecs = 0;
     }
-    else 
+    else
     {
       feedbackItem.timerSecs++;
     }
@@ -324,9 +328,9 @@ class ItemDataService {
    * Add a feedback item as a child feedback item of another feedback item.
    * This method also ensures that
    *   1) an existing parent-child association is removed from the old parent if the childFeedbackItem already had one.
-   *   2) the existing children of the child feedback item (if any) become children of the specified parent 
+   *   2) the existing children of the child feedback item (if any) become children of the specified parent
    *   feedback item as well.
-   *   3) that the child feedback item and the existing children of the child feedback item (if any) are 
+   *   3) that the child feedback item and the existing children of the child feedback item (if any) are
    *   assigned the same columnId as the parent feedback item.
    */
   public addFeedbackItemAsChild = async (boardId: string, parentFeedbackItemId: string, childFeedbackItemId: string):
@@ -340,8 +344,8 @@ class ItemDataService {
     const childFeedbackItem: IFeedbackItemDocument = await this.getFeedbackItem(boardId, childFeedbackItemId);
 
     if (!parentFeedbackItem || !childFeedbackItem) {
-      console.log(`Cannot add child for a non-existent feedback item. 
-                Board: ${boardId}, 
+      console.log(`Cannot add child for a non-existent feedback item.
+                Board: ${boardId},
                 Parent Item: ${parentFeedbackItemId},
                 Child Item: ${childFeedbackItemId}`);
       return undefined;
@@ -350,7 +354,7 @@ class ItemDataService {
     // The parent feedback item must not be a child of another group.
     if (parentFeedbackItem.parentFeedbackItemId) {
       console.log(`Cannot add child if parent is already a child in another group.
-                Board: ${boardId}, 
+                Board: ${boardId},
                 Parent Item: ${parentFeedbackItemId}`);
       return undefined;
     }
@@ -425,8 +429,8 @@ class ItemDataService {
     const feedbackItem: IFeedbackItemDocument = await this.getFeedbackItem(boardId, feedbackItemId);
 
     if (!feedbackItem) {
-      console.log(`Cannot move a non-existent feedback item. 
-              Board: ${boardId}, 
+      console.log(`Cannot move a non-existent feedback item.
+              Board: ${boardId},
               Parent Item: ${feedbackItem.parentFeedbackItemId},
               Child Item: ${feedbackItemId}`);
       return undefined;
@@ -437,8 +441,8 @@ class ItemDataService {
     if (feedbackItem.parentFeedbackItemId) {
       const parentFeedbackItem: IFeedbackItemDocument = await this.getFeedbackItem(boardId, feedbackItem.parentFeedbackItemId);
       if (!parentFeedbackItem) {
-        console.log(`The given feedback item has a non-existent parent. 
-                Board: ${boardId}, 
+        console.log(`The given feedback item has a non-existent parent.
+                Board: ${boardId},
                 Parent Item: ${feedbackItem.parentFeedbackItemId},
                 Child Item: ${feedbackItemId}`);
         return undefined;
@@ -466,7 +470,7 @@ class ItemDataService {
 
       const updatedChildFeedbackItemPromises: Promise<IFeedbackItemDocument>[] = childFeedbackItems.map((childFeedbackItem) =>
         this.updateFeedbackItem(boardId, childFeedbackItem));
-  
+
       updatedChildFeedbackItems =
         await Promise.all(updatedChildFeedbackItemPromises).then((promiseResults) => {
           return promiseResults.map((updatedChildFeedbackItem) => updatedChildFeedbackItem)
@@ -572,7 +576,7 @@ class ItemDataService {
    * Checks if the work item exists in VSTS and if not, removes it.
    * This handles the special case for when a work item is deleted in VSTS. Currently, when a work item is updated using the navigation form service
    * there is no way to determine if the item was deleted.
-   * https://github.com/MicrosoftDocs/vsts-docs/issues/1545 
+   * https://github.com/MicrosoftDocs/vsts-docs/issues/1545
    */
   public removeAssociatedItemIfNotExistsInVsts = async (boardId: string, feedbackItemId: string, associatedWorkItemId: number): Promise<IFeedbackItemDocument> => {
     let workItems: WorkItem[];


### PR DESCRIPTION
To reproduce the original issue:
- Using the most recent published version of the extension, create a retro board and add an item to the board. Add at least one vote to the item, and then delete the item. Any votes added to the item will not be returned to the user. 

Notes:
- Because a user should not be able to change the vote allocations for other users, it should not be possible to delete active feedback items which have at least one vote (it is logic intensive to iterate through the feedback item's vote collection to determine if there are only votes from the current user, so it is easier to blanket disable deletion and re-enable if votes are removed to make the vote count 0). 