### PR TITLE
Fixing PR status checks

### DIFF
--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   build:
 
+    name: Backend - Build and Test
+
     strategy:
       fail-fast: false
 

--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -6,36 +6,39 @@ on:
       - master
       - dev
       - 'releases/**'
-    paths:
-      - 'RetrospectiveExtension.Backend/**'
   pull_request:
     branches:
       - master
       - dev
       - 'releases/**'
-    paths:
-      - 'RetrospectiveExtension.Backend/**'
   workflow_dispatch:
 
 jobs:
   build:
-
     name: Backend - Build and Test
-
-    strategy:
-      fail-fast: false
-
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - '.github/**'
+              - 'RetrospectiveExtension.Backend/**'
+              - 'RetrospectiveExtension.Backend.Tests/**'
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      - if: steps.changes.outputs.src == 'true'
+        name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      - if: steps.changes.outputs.src == 'true'
+        name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - if: steps.changes.outputs.src == 'true'
+        name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      - if: steps.changes.outputs.src == 'true'
+        name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -22,7 +22,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    name: Build and Test
+    name: Frontend - Build and Test
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -6,33 +6,36 @@ on:
       - master
       - dev
       - 'releases/**'
-    paths-ignore:
-      - 'RetrospectiveExtension.Backend/**'
   pull_request:
     branches:
       - master
       - dev
       - 'releases/**'
-    paths-ignore:
-      - 'RetrospectiveExtension.Backend/**'
   workflow_dispatch:
 
 jobs:
   build:
-
+    name: Frontend - Build and Test  
     runs-on: ubuntu-latest
-
-    name: Frontend - Build and Test
-
     steps:
-    - uses: actions/checkout@v2
-      name: Check out repository
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - '.github/**'
+              - 'RetrospectiveExtension.Frontend/**'
 
-    - run: |
-        npm install
-        npm run lint
-        npm run build:p
-        npm run test
-        npm run pack:p
-      name: Build and Test
-      working-directory: 'RetrospectiveExtension.Frontend'
+      - if: steps.changes.outputs.src == 'true'
+        uses: actions/checkout@v2
+        name: Check out repository
+
+      - if: steps.changes.outputs.src == 'true'
+        run: |
+          npm install
+          npm run lint
+          npm run build:p
+          npm run test
+          npm run pack:p
+        name: Build and Test
+        working-directory: 'RetrospectiveExtension.Frontend'


### PR DESCRIPTION
Recently, we've enabled status checks for PR that requires both `CI - Backend` and `CI - Frontend` PASS status. Since we were using `path` and `path-ignore` attributes in the yaml file for trigger conditions, that may not trigger both workflows and PRs could be in a stuck situation. This is a known issue of GitHub Actions for pretty long time:

https://github.community/t/feature-request-conditional-required-checks/16761/23

As a workaround, we're now using [dorny paths-filter](https://github.com/dorny/paths-filter#conditional-execution) to filter paths.