### PR TITLE
[1494, 1498] Adding unit tests for backend component and replacing GitHub Autobuild

### DIFF
--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -44,6 +44,15 @@ jobs:
 
       - if: steps.changes.outputs.src == 'true'
         run: |
-          dotnet test
+          dotnet test --logger "trx;LogFileName=test-results.trx"
         name: Test
         working-directory: 'RetrospectiveExtension.Backend.Tests'
+
+      - if: steps.changes.outputs.src == 'true'
+        name: Upload backend test report
+        uses: dorny/test-reporter@v1.5.0
+        with:
+          name: Dotnet Tests
+          path: TestResults/test-results.trx
+          reporter: dotnet-trx
+          working-directory: 'RetrospectiveExtension.Backend.Tests'

--- a/.github/workflows/ci_backend.yml
+++ b/.github/workflows/ci_backend.yml
@@ -31,13 +31,19 @@ jobs:
               - 'RetrospectiveExtension.Backend.Tests/**'
 
       - if: steps.changes.outputs.src == 'true'
-        name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.404'
 
       - if: steps.changes.outputs.src == 'true'
-        name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        run: |
+          dotnet restore
+          dotnet build
+        name: Build
+        working-directory: 'RetrospectiveExtension.Backend'
 
       - if: steps.changes.outputs.src == 'true'
-        name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        run: |
+          dotnet test
+        name: Test
+        working-directory: 'RetrospectiveExtension.Backend.Tests'

--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    name: Frontend - Build and Test  
+    name: Frontend - Build and Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -270,3 +270,6 @@ dev_certs.json
 # Jest test report
 RetrospectiveExtension.FrontEnd/reports/
 RetrospectiveExtension.FrontEnd/coverage/
+
+# Dotnet test results
+RetrospectiveExtension.Backend.Tests/TestResult

--- a/.gitignore
+++ b/.gitignore
@@ -272,4 +272,4 @@ RetrospectiveExtension.FrontEnd/reports/
 RetrospectiveExtension.FrontEnd/coverage/
 
 # Dotnet test results
-RetrospectiveExtension.Backend.Tests/TestResult
+RetrospectiveExtension.Backend.Tests/TestResults

--- a/RetrospectiveExtension.Backend.Tests/ReflectHubTests.cs
+++ b/RetrospectiveExtension.Backend.Tests/ReflectHubTests.cs
@@ -1,0 +1,185 @@
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using ReflectBackend;
+using System.Threading;
+using Xunit;
+using static ReflectBackend.ReflectBackendSignals;
+
+namespace RetrospectiveExtension.Backend.Tests
+{
+  public class ReflectHubTests
+  {
+    [Fact]
+    public async void BroadcastDeletedBoardTest()
+    {
+      using (var hub = new ReflectHub())
+      {
+        // Set up mock objects
+        var mockClientProxy = new Mock<IClientProxy>();
+        var mockClients = new Mock<IHubCallerClients>();
+        mockClients.SetupGet(x => x.Others).Returns(mockClientProxy.Object);
+        hub.Clients = mockClients.Object;
+
+        // Invoke method
+        await hub.BroadcastDeletedBoard("teamId", "reflectBoardId");
+
+        // Assert
+        mockClientProxy.Verify(x => x.SendCoreAsync(
+          receiveDeletedBoard.ToString(),
+          new string[] {"teamId", "reflectBoardId"},
+          default(CancellationToken)));
+      }
+    }
+
+    [Fact]
+    public async void BroadcastNewBoardTest()
+    {
+      using (var hub = new ReflectHub())
+      {
+        // Set up mock objects
+        var mockClientProxy = new Mock<IClientProxy>();
+        var mockClients = new Mock<IHubCallerClients>();
+        mockClients.SetupGet(x => x.Others).Returns(mockClientProxy.Object);
+        hub.Clients = mockClients.Object;
+
+        // Invoke method
+        await hub.BroadcastNewBoard("teamId", "reflectBoardId");
+
+        // Assert
+        mockClientProxy.Verify(x => x.SendCoreAsync(
+          receiveNewBoard.ToString(),
+          new string[] {"teamId", "reflectBoardId"},
+          default(CancellationToken)));
+      }
+    }
+
+    [Fact]
+    public async void BroadcastUpdatedBoardTest()
+    {
+      using (var hub = new ReflectHub())
+      {
+        // Set up mock objects
+        var mockClientProxy = new Mock<IClientProxy>();
+        var mockClients = new Mock<IHubCallerClients>();
+        mockClients.SetupGet(x => x.Others).Returns(mockClientProxy.Object);
+        hub.Clients = mockClients.Object;
+
+        // Invoke method
+        await hub.BroadcastUpdatedBoard("teamId", "reflectBoardId");
+
+        // Assert
+        mockClientProxy.Verify(x => x.SendCoreAsync(
+          receiveUpdatedBoard.ToString(),
+          new string[] {"teamId", "reflectBoardId"},
+          default(CancellationToken)));
+      }
+    }
+
+    [Fact]
+    public async void BroadcastDeletedItemTest()
+    {
+      using (var hub = new ReflectHub())
+      {
+        // Set up mock objects
+        var mockClientProxy = new Mock<IClientProxy>();
+        var mockClients = new Mock<IHubCallerClients>();
+        mockClients.Setup(x => x.OthersInGroup(It.IsAny<string>())).Returns(mockClientProxy.Object);
+        hub.Clients = mockClients.Object;
+
+        // Invoke method
+        await hub.BroadcastDeletedItem("reflectBoardId", "columnId", "feedbackItemId");
+
+        // Assert
+        mockClients.Verify(x => x.OthersInGroup("reflectBoardId"));
+        mockClientProxy.Verify(x => x.SendCoreAsync(
+          receiveDeletedItem.ToString(),
+          new string[] {"columnId", "feedbackItemId"},
+          default(CancellationToken)));
+      }
+    }
+
+    [Fact]
+    public async void BroadcastNewItemTest()
+    {
+      using (var hub = new ReflectHub())
+      {
+        // Set up mock objects
+        var mockClientProxy = new Mock<IClientProxy>();
+        var mockClients = new Mock<IHubCallerClients>();
+        mockClients.Setup(x => x.OthersInGroup(It.IsAny<string>())).Returns(mockClientProxy.Object);
+        hub.Clients = mockClients.Object;
+
+        // Invoke method
+        await hub.BroadcastNewItem("reflectBoardId", "columnId", "feedbackItemId");
+
+        // Assert
+        mockClients.Verify(x => x.OthersInGroup("reflectBoardId"));
+        mockClientProxy.Verify(x => x.SendCoreAsync(
+          receiveNewItem.ToString(),
+          new string[] {"columnId", "feedbackItemId"},
+          default(CancellationToken)));
+      }
+    }
+
+    [Fact]
+    public async void BroadcastUpdatedItem()
+    {
+      using (var hub = new ReflectHub())
+      {
+        // Set up mock objects
+        var mockClientProxy = new Mock<IClientProxy>();
+        var mockClients = new Mock<IHubCallerClients>();
+        mockClients.Setup(x => x.OthersInGroup(It.IsAny<string>())).Returns(mockClientProxy.Object);
+        hub.Clients = mockClients.Object;
+
+        // Invoke method
+        await hub.BroadcastUpdatedItem("reflectBoardId", "columnId", "feedbackItemId");
+
+        // Assert
+        mockClients.Verify(x => x.OthersInGroup("reflectBoardId"));
+        mockClientProxy.Verify(x => x.SendCoreAsync(
+          receiveUpdatedItem.ToString(),
+          new string[] {"columnId", "feedbackItemId"},
+          default(CancellationToken)));
+      }
+    }
+
+    [Fact]
+    public async void JoinReflectBoardGroupTest()
+    {
+      using (var hub = new ReflectHub())
+      {
+        // Set up mock objects
+        var mockGroups = new Mock<IGroupManager>();
+        mockGroups.Setup(x => x.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
+        hub.Groups = mockGroups.Object;
+        hub.Context = Mock.Of<HubCallerContext>();
+
+        // Invoke method
+        await hub.JoinReflectBoardGroup("reflectBoardId");
+
+        // Assert
+        mockGroups.Verify(x => x.AddToGroupAsync(It.IsAny<string>(), "reflectBoardId", It.IsAny<CancellationToken>()));
+      }
+    }
+
+    [Fact]
+    public async void LeaveReflectBoardGroupTest()
+    {
+      using (var hub = new ReflectHub())
+      {
+        // Set up mock objects
+        var mockGroups = new Mock<IGroupManager>();
+        mockGroups.Setup(x => x.AddToGroupAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()));
+        hub.Groups = mockGroups.Object;
+        hub.Context = Mock.Of<HubCallerContext>();
+
+        // Invoke method
+        await hub.LeaveReflectBoardGroup("reflectBoardId");
+
+        // Assert
+        mockGroups.Verify(x => x.RemoveFromGroupAsync(It.IsAny<string>(), "reflectBoardId", It.IsAny<CancellationToken>()));
+      }
+    }
+  }
+}

--- a/RetrospectiveExtension.Backend.Tests/RetrospectiveExtension.Backend.Tests.csproj
+++ b/RetrospectiveExtension.Backend.Tests/RetrospectiveExtension.Backend.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <ProjectReference Include="../RetrospectiveExtension.Backend/CollaborationStateService.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/RetrospectiveExtension.Backend/ReflectHub.cs
+++ b/RetrospectiveExtension.Backend/ReflectHub.cs
@@ -3,9 +3,20 @@ using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
+using static ReflectBackend.ReflectBackendSignals;
 
 namespace ReflectBackend
 {
+  public enum ReflectBackendSignals
+  {
+    receiveNewItem,
+    receiveUpdatedItem,
+    receiveUpdatedBoard,
+    receiveDeletedItem,
+    receiveDeletedBoard,
+    receiveNewBoard
+  }
+
   [Authorize]
   public class ReflectHub : Hub
   {
@@ -26,7 +37,7 @@ namespace ReflectBackend
     public Task BroadcastDeletedBoard(string teamId, string reflectBoardId)
     {
       _insights.TrackEvent("Broadcasting delete board");
-      return Clients.Others.SendAsync("receiveDeletedBoard", teamId, reflectBoardId);
+      return Clients.Others.SendAsync(receiveDeletedBoard.ToString(), teamId, reflectBoardId);
     }
 
     /// <summary>
@@ -38,7 +49,7 @@ namespace ReflectBackend
     public Task BroadcastDeletedItem(string reflectBoardId, string columnId, string feedbackItemId)
     {
       _insights.TrackEvent("Broadcasting delete item");
-      return Clients.OthersInGroup(reflectBoardId).SendAsync("receiveDeletedItem", columnId, feedbackItemId);
+      return Clients.OthersInGroup(reflectBoardId).SendAsync(receiveDeletedItem.ToString(), columnId, feedbackItemId);
     }
 
     /// <summary>
@@ -49,7 +60,7 @@ namespace ReflectBackend
     public Task BroadcastNewBoard(string teamId, string reflectBoardId)
     {
       _insights.TrackEvent("Broadcasting new board");
-      return Clients.Others.SendAsync("receiveNewBoard", teamId, reflectBoardId);
+      return Clients.Others.SendAsync(receiveNewBoard.ToString(), teamId, reflectBoardId);
     }
 
     /// <summary>
@@ -61,7 +72,7 @@ namespace ReflectBackend
     public Task BroadcastNewItem(string reflectBoardId, string columnId, string feedbackItemId)
     {
       _insights.TrackEvent("Broadcasting new item");
-      return Clients.OthersInGroup(reflectBoardId).SendAsync("receiveNewItem", columnId, feedbackItemId);
+      return Clients.OthersInGroup(reflectBoardId).SendAsync(receiveNewItem.ToString(), columnId, feedbackItemId);
     }
 
     /// <summary>
@@ -72,7 +83,7 @@ namespace ReflectBackend
     public Task BroadcastUpdatedBoard(string teamId, string reflectBoardId)
     {
       _insights.TrackEvent("Broadcasting board update");
-      return Clients.Others.SendAsync("receiveUpdatedBoard", teamId, reflectBoardId);
+      return Clients.Others.SendAsync(receiveUpdatedBoard.ToString(), teamId, reflectBoardId);
     }
 
     /// <summary>
@@ -84,7 +95,7 @@ namespace ReflectBackend
     public Task BroadcastUpdatedItem(string reflectBoardId, string columnId, string feedbackItemId)
     {
       _insights.TrackEvent("Broadcasting item update");
-      return Clients.OthersInGroup(reflectBoardId).SendAsync("receiveUpdatedItem", columnId, feedbackItemId);
+      return Clients.OthersInGroup(reflectBoardId).SendAsync(receiveUpdatedItem.ToString(), columnId, feedbackItemId);
     }
 
     /// <summary>


### PR DESCRIPTION
- Replacing GitHub autobuild with manual build steps so that we have more control over the building/testing process and speed up build time (from 4 minutes to 40 seconds). Note that we'll be adding back code scan/analysis later in one of our coming user story.
- Adding unit tests for backend components.
- Adding test visualization for backend components.

In collaboration with @nexilus18 