### PR TITLE
User Story #1413: Obscure Feedback of Others During Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 Retrospectives is an [Azure DevOps](https://dev.azure.com) extension to perform _smart and efficient retrospectives from within the Azure DevOps pipeline._
 
-Retrospectives are an important part of the software engineering cycle. Teams often use external retrospective tools, white board with Post-its, OneNote, etc to conduct retrospectives. The data then needs to be collated, and any actionable items need to be created in your Azure DevOps pipeline. The [Retrospectives extension](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.team-retrospectives) allows you to do all this and more from within Azure DevOps.
+Retrospectives are an important part of the software engineering cycle. Teams often use external
+retrospective tools, white board with Post-its, OneNote, etc to conduct retrospectives. The data
+then needs to be collated, and any actionable items need to be created in your Azure DevOps pipeline.
+The [Retrospectives extension](https://marketplace.visualstudio.com/items?itemName=ms-devlabs.team-retrospectives)
+allows you to do all this and more from within Azure DevOps.
 
 ## Table of Contents
 
@@ -29,60 +33,129 @@ The extension can be installed from [Azure DevOps Marketplace](https://marketpla
 
 1. Navigate to the Azure 'Boards' tab in your account. Select the 'Retrospectives' tab under boards.
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/boardandretrospectivestab.png)
+    ![A screenshot of the Azure Devops lefthand navigation. Under the Boards heading, the extension for
+    the retrospective is circled in red.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/boardandretrospectivestab.png)
 
-2. This will navigate you to the Retrospectives page. Select your Azure DevOps team from the selector in the header.
+2. This will navigate you to the Retrospectives page. Select your Azure DevOps team from the selector
+in the header.
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/teamselection.png)
+    ![A screenshot of the Retrospective tool's landing page. At the top of the page there is a dropdown
+    selection for which team circled in red.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/teamselection.png)
 
-3. Create a new retrospective using the 'Create Board' button. If you have created retrospectives before, use the selector to go to a particular retrospective, or create a new one using the options button and then clicking on 'Create new board'.
+3. Create a new retrospective using the 'Create Board' button. If you have created retrospectives
+before, use the selector to go to a particular retrospective, or create a new one using the options
+button and then clicking on 'Create new board'.
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/createretrospective.png)
+    ![A screenshot of the Retrospective tool's team page if there are no existing retrospective boards.
+    No board has been created so there is a message of 'Get started with your first retrospective' in
+    the center of the screen with a simplified image of a two-colomned retrospective. Below that there
+    is a blue button to click that says 'Create Board,' which is circled in red.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/createretrospective.png)
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/createretrospective2.png)
-  When you select **New Board** or **Create new baord** as above, you will see the following dialog: 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/createretrospectivewithmaxvotes.png)
-</br>
-  Please enter the appropriate information:
-   - **Retrospective Title**: Enter appropriate text 
-   - **Make all feedback anonymous**: When you select this checkbox, user identities for the item creators will not be displayed
-   - **Only show feedback after Collect phase**: When selected, users cannot see other users input till the Collect phase is completed by moving to another phase
-   - **Max Votes per User (Current 5)**: This options lets the board creator control how many total votes (across all columns) that each user can have. Default is 5. While this option can be updated through the _Edit retrospective_ option, please note that this update cannot decrement votes already in place. 
-   - **Colums**: You can either Apply from a preselected templates or individually select and configure columns
-  </br> </br>Retrospective Title is the minimum 'required' information (other fields can stay at default as needed). Ones the title is provided, the [Save] button is enabled. Save the retrospective using the [Save] button.
+    ![A screen shot of the Retrospective tool's team view if there are any existing boards. From a
+    dropdown beside an existing board's title, which is the Board Actions Menu. The first selection on
+    the list is the 'Create new board,' which is circled in red.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/createretrospective2.png)
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/navigatetoretrospective.png)
-  Once you have created the retrospective boards and you want to select a board different from the currently displayed board, click on the board name (e.g. Demo board in the image) and select the desired board. You can use the search box to find the appropriate boards if you have a large number of boards. 
+    When you select **New Board** or **Create new baord** as above, you will see the following dialog:
+    ![A screenshot showing the modal box that controls the initial settings for creating a retrospective
+    board. The settings include: a text field for title of the retrospective; a checkbox for each of
+    the settings about feedback visibility/anonymity; a number field for the maximum number of votes
+    each participant can use; and the different columns to include in the retrospective, either
+    customized or loaded from a template. The maximum  number of votes field is highlighted in yellow.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/createretrospectivewithmaxvotes.png)
+  </br>
+    Please enter the appropriate information:
 
-4. If you created a new retrospective in step 3, give your retrospective an appropriate name and click 'Save'. This will create and navigate you to your newly created retrospective.
+    - **Retrospective Title**: Enter appropriate text
+    - **Make all feedback anonymous**: When you select this checkbox, user identities for the item
+        reators will not be displayed.
+    - **Only show feedback after Collect phase**: When selected, users cannot see other users input
+        until they have moved to another phase. Other users' feedback will be blurred.
+    - **Max Votes per User (Current 5)**: This options lets the board creator control how many total
+        votes (across all columns) that each user can have. Default is 5. While this option can be updated
+        through the _Edit retrospective_ option, please note that this update cannot decrement votes
+        already in place.
+    - **Colums**: You can either Apply from a preselected templates or individually select and configure
+        columns
+    </br> </br>Retrospective Title is the minimum 'required' information (other fields can stay at
+        default as needed). Ones the title is provided, the [Save] button is enabled. Save the retrospective
+        using the [Save] button.
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/createretrospectiveform.png)
+        ![A screenshot showing the dropdown for searching available retrospective boards after they've
+        been created. The text field to search in circled in red.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/navigatetoretrospective.png)
 
-5. Once you create a new retrospective, you can share a link to it to all participants. Users can then access that link even from their mobile browsers to participate in the retrospective. The extension offers real time synchronisation, so all users will see the most upto date information without having to refresh the page.
+      Once you have created the retrospective boards and you want to select a board different from the
+      currently displayed board, click on the board name (e.g. Demo board in the image) and select the
+      desired board. You can use the search box to find the appropriate boards if you have a large number
+      of boards.
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/boardlink.png)
+4. If you created a new retrospective in step 3, give your retrospective an appropriate name and
+  click 'Save'. This will create and navigate you to your newly created retrospective.
 
-6. Each Retrospective by default has 2 columns, one for things that went well and another for those that did not. Performing a retrospective is divided into 4 phases.
+      ![A screenshot on the first 'Create New Board' modal. Underneath the stylized illustration of
+      a retrospective board, the text field for the board's title has an example title of 'Retrospective
+      December 2018' with two buttons beneah it, one for 'Save' and one to cancel out of the modal.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/createretrospectiveform.png)
 
-  - **Collect** - In this phase feedback is collected from all participants. Users can add feedback under either of the columns using the 'Add new card' button. Once feedback from all users is collected, move onto the next phase.
+5. Once you create a new retrospective, you can share a link to it to all participants. Users can
+  then access that link even from their mobile browsers to participate in the retrospective. The
+  extension offers real time synchronisation, so all users will see the most upto date information
+  without having to refresh the page.
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/createfeedback.png)
+      ![A screenshot of the dropdown from the Board Actions Menu. The option for 'Copy Board Link' is
+      circled in red.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/boardlink.png)
 
-  - **Group** - In this phase, the similar feedback is grouped together. If you feel 2 feedback items are similar, drag one onto another to group them together. Dragging any item onto a group, will add items to that group. Once all similar items are grouped together, move on to the next phase.
+6. Each Retrospective by default has 2 columns, one for things that went well and another for those
+  that did not. Performing a retrospective is divided into 4 phases.
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/groupfeedback.png)
+- **Collect** - In this phase feedback is collected from all participants. Users can add feedback
+    under either of the columns using the 'Add new card' button. Once feedback from all users is
+    collected, move onto the next phase.
 
-  - **Vote** - In this phase, participants will individually go through all the feedback items and vote on the ones they feel are important, by clicking on the 'Upvote' icon. Users can reduce their number of votes on a specific item by clicking on the 'Downvote' icon. </br> Note the _Max Votes per User_ set by the board creator are displayed above the board along with the votes used by the user. Votes used by the user are updated in real time as the user clicks on 'Upvote' and 'Downvote' icons.</br></br> Once everyone is done voting, move on to the next phase.
+    ![A screenshot of an example retrospective board column. The button for 'Add new card' is circled
+    in yellow, and an empty feedback item card is also circled in yellow.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/createfeedback.png)
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/maxvotes.png)
+- **Group** - In this phase, the similar feedback is grouped together. If you feel 2 feedback items
+    are similar, drag one onto another to group them together. Dragging any item onto a group, will add
+    items to that group. Once all similar items are grouped together, move on to the next phase.
 
-  - **Act** - In this phase, the team will go through each feedback item and create work items in Azure DevOps if needed. Click on the 'Add action item' button on a feedback card, and select the type of work item that needs to be created. This will open up the standard Azure DevOps work item creation form. Enter the work item details and save. This will create the work item in your Azure DevOps account and also associate it to the feedback item.
+    ![A screenshot of an example retrospective in the 'Group' phase shows a number of feedback items,
+    two rows of two cards. Of the bottom two cards, there is an indicator that it is composed of
+    multiple cards with collapsible dropdowns of two items. The left grouping is collapsed so only
+    the 'top' card is visible, and the right grouping is expanded to show all the items in the group
+    listed.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/groupfeedback.png)
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/addactionitem.png)
+- **Vote** - In this phase, participants will individually go through all the feedback items and vote
+    on the ones they feel are important, by clicking on the 'Upvote' icon. Users can reduce their number
+    of votes on a specific item by clicking on the 'Downvote' icon. </br> Note the _Max Votes per User_
+    set by the board creator are displayed above the board along with the votes used by the user. Votes
+    used by the user are updated in real time as the user clicks on 'Upvote' and 'Downvote' icons.
+    </br></br> Once everyone is done voting, move on to the next phase.
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/newbugform.png)
+    ![A screenshot of an example retrospective in the 'Vote' phase. Along the top of the page there
+    is a subheading that indicates that the maximum number of votes per participant is 5, and that
+    the example user has already voted 4 times; this subheading is circled in yellow. There are three
+    example feedback items that are in two columns. 'Item2' and 'Item1' are in the 'What went well'
+    column and 'Item3' is in the 'What didn't go well' column. The four votes are indicated on each
+    of the cards: 'Item2' has two votes, 'Item1' has one vote, and 'Item3' has one. The number of
+    votes is circled in yellow.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/maxvotes.png)
 
-  ![Group](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/addactionitemsaved.png)
+- **Act** - In this phase, the team will go through each feedback item and create work items in Azure
+    DevOps if needed. Click on the 'Add action item' button on a feedback card, and select the type of
+    work item that needs to be created. This will open up the standard Azure DevOps work item creation
+    form. Enter the work item details and save. This will create the work item in your Azure DevOps
+    account and also associate it to the feedback item.
+
+    ![A screenshot of an example retrospective in the 'Act' phase. On one of the example feedback
+    items, the button for 'Add Action Item' has been pressed to reveal a selection of options. The
+    user has the option to create a number of different Azure Dev Ops items, like adding a bug, a
+    user story, and others. In this case, the item that is circled in red is the 'Bug' option.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/addactionitem.png)
+
+    ![A screenshot of a new Azure Dev ops Bug item, which is understood to be the result of the
+    previous screenshot, that is in a modal on top of the example retrospective. A title of 'new bug'
+    has been entered and has been circled in red. The button to 'Save and Close' is also circled.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/newbugform.png)
+
+    ![A screenshot of the retrospective board again, that is understood to be the result of the new
+    bug being created, saved, and then closed. The difference is now beneath the feedback card, there
+    is a list of connected 'Action Items' that includes this new bug story. This new bug is circled
+    in red.](https://github.com/microsoft/vsts-extension-retrospectives/raw/master/RetrospectiveExtension.Frontend/images/usage/addactionitemsaved.png)
 
 ## Contribute
 

--- a/RetrospectiveExtension.Frontend/components/editableText.tsx
+++ b/RetrospectiveExtension.Frontend/components/editableText.tsx
@@ -1,5 +1,7 @@
 ﻿import * as React from 'react';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { withAITracking } from '@microsoft/applicationinsights-react-js';
+import { reactPlugin } from '../utilities/external/telemetryClient';
 
 export interface EditableTextProps {
   isDisabled?: boolean;
@@ -16,7 +18,7 @@ export interface EditableTextState {
   hasErrors: boolean;
 }
 
-export default class EditableText extends React.Component<EditableTextProps, EditableTextState> {
+class EditableText extends React.Component<EditableTextProps, EditableTextState> {
   constructor(props: EditableTextProps) {
     super(props);
 
@@ -194,3 +196,5 @@ export default class EditableText extends React.Component<EditableTextProps, Edi
     );
   }
 }
+
+export default withAITracking(reactPlugin, EditableText);

--- a/RetrospectiveExtension.Frontend/components/editableText.tsx
+++ b/RetrospectiveExtension.Frontend/components/editableText.tsx
@@ -1,7 +1,5 @@
 ﻿import * as React from 'react';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import { withAITracking } from '@microsoft/applicationinsights-react-js';
-import { reactPlugin } from '../utilities/external/telemetryClient';
 
 export interface EditableTextProps {
   isDisabled?: boolean;
@@ -18,7 +16,7 @@ export interface EditableTextState {
   hasErrors: boolean;
 }
 
-class EditableText extends React.Component<EditableTextProps, EditableTextState> {
+export default class EditableText extends React.Component<EditableTextProps, EditableTextState> {
   constructor(props: EditableTextProps) {
     super(props);
 
@@ -188,7 +186,7 @@ class EditableText extends React.Component<EditableTextProps, EditableTextState>
           tabIndex={0}
           onKeyDown={this.props.isDisabled ? () => { } : this.handleEditKeyDown}
           onClick={this.props.isDisabled ? () => { } : this.handleEdit}
-          aria-label={'Feedback title is ' + this.props.text + '. Click to edit.'}
+          aria-label={'Feedback title is ' + (this.props.isDisabled ? 'obscured during collection.' : this.props.text + '. Click to edit.')}
           aria-required={true}>
           {this.props.text}
         </p>
@@ -196,5 +194,3 @@ class EditableText extends React.Component<EditableTextProps, EditableTextState>
     );
   }
 }
-
-export default withAITracking(reactPlugin, EditableText);

--- a/RetrospectiveExtension.Frontend/components/editableText.tsx
+++ b/RetrospectiveExtension.Frontend/components/editableText.tsx
@@ -47,7 +47,7 @@ class EditableText extends React.Component<EditableTextProps, EditableTextState>
         newText: "",
         hasErrors: true
       });
-    return;
+      return;
     }
 
     this.setState({
@@ -176,9 +176,9 @@ class EditableText extends React.Component<EditableTextProps, EditableTextState>
               e.stopPropagation();
             }}
           />
-            {this.state.hasErrors && <span className="input-validation-message">This cannot be empty.</span>}
-          </div>
-        );
+          {this.state.hasErrors && <span className="input-validation-message">This cannot be empty.</span>}
+        </div>
+      );
     }
 
     return (
@@ -186,9 +186,9 @@ class EditableText extends React.Component<EditableTextProps, EditableTextState>
         className="editable-text-container">
         <p className="editable-text"
           tabIndex={0}
-          onKeyDown={this.props.isDisabled ? () => {} : this.handleEditKeyDown}
-          onClick={this.props.isDisabled ? () => {} : this.handleEdit}
-          aria-label={'Feedback title is' + this.props.text + '. Click to edit.'}
+          onKeyDown={this.props.isDisabled ? () => { } : this.handleEditKeyDown}
+          onClick={this.props.isDisabled ? () => { } : this.handleEdit}
+          aria-label={'Feedback title is ' + this.props.text + '. Click to edit.'}
           aria-required={true}>
           {this.props.text}
         </p>

--- a/RetrospectiveExtension.Frontend/components/feedbackBoardContainer.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoardContainer.tsx
@@ -12,7 +12,7 @@ import WorkflowStage from './workflowStage';
 import BoardDataService from '../dal/boardDataService';
 import { IFeedbackBoardDocument, IFeedbackColumn, IFeedbackItemDocument } from '../interfaces/feedback';
 import { reflectBackendService } from '../dal/reflectBackendService';
-import BoardSummaryTable  from './boardSummaryTable';
+import BoardSummaryTable from './boardSummaryTable';
 import FeedbackBoardMetadataForm from './feedbackBoardMetadataForm';
 import FeedbackBoard from '../components/feedbackBoard';
 
@@ -82,14 +82,14 @@ export interface FeedbackBoardContainerState {
   isDesktop: boolean;
   isAutoResizeEnabled: boolean;
   feedbackItems: IFeedbackItemDocument[];
-  contributors: {id: string, name: string, imageUrl: string}[];
+  contributors: { id: string, name: string, imageUrl: string }[];
   effectivenessMeasurementSummary: { question: string, average: number }[];
   actionItemIds: number[];
   members: TeamMember[];
   castedVoteCount: number;
 }
 
- class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps, FeedbackBoardContainerState> {
+class FeedbackBoardContainer extends React.Component<FeedbackBoardContainerProps, FeedbackBoardContainerState> {
   constructor(props: FeedbackBoardContainerProps) {
     super(props);
     this.state = {
@@ -239,7 +239,7 @@ export interface FeedbackBoardContainerState {
   }
 
   // private handleErrorEvent = async (errorEvent: ErrorEvent) => {
-    // TODO (enpolat) : appInsightsClient.trackException(errorEvent.error);
+  // TODO (enpolat) : appInsightsClient.trackException(errorEvent.error);
   // }
 
   private handleNewBoardAvailable = async (teamId: string, boardId: string) => {
@@ -407,11 +407,10 @@ export interface FeedbackBoardContainerState {
       queryParams = (new URL(document.location.href)).searchParams;
 
       if (!queryParams) {
-        if (!this.props.isHostedAzureDevOps)
-        {
+        if (!this.props.isHostedAzureDevOps) {
           throw new Error("URL-related issue occurred with on-premise Azure DevOps");
         }
-        else if (!document.referrer){
+        else if (!document.referrer) {
           throw new Error("URL-related issue occurred with this URL: (Empty URL)");
         }
         else {
@@ -871,7 +870,7 @@ export interface FeedbackBoardContainerState {
           isNewBoardCreation={isNewBoardCreation}
           currentBoard={this.state.currentBoard}
           teamId={this.state.currentTeam.id}
-          maxvotesPerUser = {this.state.maxvotesPerUser}
+          maxvotesPerUser={this.state.maxvotesPerUser}
           placeholderText={placeholderText}
           initialValue={initialValue}
           onFormSubmit={onSubmit}
@@ -1053,7 +1052,7 @@ export interface FeedbackBoardContainerState {
     }
 
     return (
-      <div className={this.state.isDesktop? ViewMode.Desktop : ViewMode.Mobile}>
+      <div className={this.state.isDesktop ? ViewMode.Desktop : ViewMode.Mobile}>
         <div id="extension-header">
           <div className="extension-title-text" aria-label="Retrospectives">
             Retrospectives
@@ -1067,7 +1066,7 @@ export interface FeedbackBoardContainerState {
             selectorListItemOnClick={this.changeSelectedTeam}
             title={"Team"}
           />
-          <div style={{flexGrow:1}}></div>
+          <div style={{ flexGrow: 1 }}></div>
           <ExtensionSettingsMenu isDesktop={this.state.isDesktop} onScreenViewModeChanged={this.toggleAndFixResolution} />
         </div>
         <div className="pivot-container">
@@ -1134,26 +1133,26 @@ export interface FeedbackBoardContainerState {
                       </div>
                     </div>
                     <div className="feedback-workflow-wrapper">
-                    { this.state.currentBoard.isIncludeTeamEffectivenessMeasurement &&
-                      <>
-                        <Dialog
-                          hidden={this.state.isIncludeTeamEffectivenessMeasurementDialogHidden}
-                          onDismiss={() => { this.setState({ isIncludeTeamEffectivenessMeasurementDialogHidden: true }); }}
-                          dialogContentProps={{
-                            type: DialogType.close,
-                          }}
-                          minWidth={640}
-                          modalProps={{
-                            isBlocking: true,
-                            containerClassName: 'prime-directive-dialog',
-                            className: 'retrospectives-dialog-modal',
-                          }}>
+                      {this.state.currentBoard.isIncludeTeamEffectivenessMeasurement &&
+                        <>
+                          <Dialog
+                            hidden={this.state.isIncludeTeamEffectivenessMeasurementDialogHidden}
+                            onDismiss={() => { this.setState({ isIncludeTeamEffectivenessMeasurementDialogHidden: true }); }}
+                            dialogContentProps={{
+                              type: DialogType.close,
+                            }}
+                            minWidth={640}
+                            modalProps={{
+                              isBlocking: true,
+                              containerClassName: 'prime-directive-dialog',
+                              className: 'retrospectives-dialog-modal',
+                            }}>
                             <DialogContent>
-                              <div style={{ color:"#008000" }}><i className="fa fa-info-circle" />&nbsp;All answers will be saved anonymously</div>
+                              <div style={{ color: "#008000" }}><i className="fa fa-info-circle" />&nbsp;All answers will be saved anonymously</div>
                               <div>Legend: 1 is Strongly Disagree, 10 is Strongly Agree</div>
                               <table className="team-effectiveness-measurement-table">
                                 <thead>
-                                <tr>
+                                  <tr>
                                     <th></th>
                                     <th></th>
                                     <th colSpan={6} style={{ borderLeft: "1px solid black", borderRight: "1px solid black" }}>Unfavorable</th>
@@ -1211,35 +1210,35 @@ export interface FeedbackBoardContainerState {
                               <DefaultButton onClick={() => { this.setState({ isIncludeTeamEffectivenessMeasurementDialogHidden: true }); }} text="Cancel" />
                               <PrimaryButton onClick={() => { saveTeamEffectivenessMeasurement(); }} text="Submit" />
                             </DialogFooter>
-                        </Dialog>
-                        <TooltipHost
-                          hostClassName="toggle-carousel-button-tooltip-wrapper"
-                          content="Measure Team Effectiveness"
-                          calloutProps={{ gapSpace: 0 }}>
-                          <ActionButton
-                            className="toggle-carousel-button"
-                            onClick={() => { this.setState({ isIncludeTeamEffectivenessMeasurementDialogHidden: false }); }}>
-                            <span className="ms-Button-icon"><i className="fas fa-chart-line"></i></span>&nbsp;
-                            <span className="ms-Button-label">Measure Team Effectiveness</span>
-                          </ActionButton>
-                        </TooltipHost>
-                      </>
+                          </Dialog>
+                          <TooltipHost
+                            hostClassName="toggle-carousel-button-tooltip-wrapper"
+                            content="Measure Team Effectiveness"
+                            calloutProps={{ gapSpace: 0 }}>
+                            <ActionButton
+                              className="toggle-carousel-button"
+                              onClick={() => { this.setState({ isIncludeTeamEffectivenessMeasurementDialogHidden: false }); }}>
+                              <span className="ms-Button-icon"><i className="fas fa-chart-line"></i></span>&nbsp;
+                              <span className="ms-Button-label">Measure Team Effectiveness</span>
+                            </ActionButton>
+                          </TooltipHost>
+                        </>
                       }
-                      { this.state.currentBoard.displayPrimeDirective &&
-                      <>
-                        <Dialog
-                          hidden={this.state.isPrimeDirectiveDialogHidden}
-                          onDismiss={() => { this.setState({ isPrimeDirectiveDialogHidden: true }); }}
-                          dialogContentProps={{
-                            type: DialogType.close,
-                            title: 'The Prime Directive',
-                          }}
-                          minWidth={600}
-                          modalProps={{
-                            isBlocking: true,
-                            containerClassName: 'prime-directive-dialog',
-                            className: 'retrospectives-dialog-modal',
-                          }}>
+                      {this.state.currentBoard.displayPrimeDirective &&
+                        <>
+                          <Dialog
+                            hidden={this.state.isPrimeDirectiveDialogHidden}
+                            onDismiss={() => { this.setState({ isPrimeDirectiveDialogHidden: true }); }}
+                            dialogContentProps={{
+                              type: DialogType.close,
+                              title: 'The Prime Directive',
+                            }}
+                            minWidth={600}
+                            modalProps={{
+                              isBlocking: true,
+                              containerClassName: 'prime-directive-dialog',
+                              className: 'retrospectives-dialog-modal',
+                            }}>
                             <DialogContent>
                               The purpose of the Prime Directive is to assure that a retrospective has the right culture to make it a positive and result oriented event. It makes a retrospective become an effective team gathering to learn and find solutions to improve the way of working.
                               <br /><br />
@@ -1251,19 +1250,19 @@ export interface FeedbackBoardContainerState {
                               <DefaultButton onClick={() => { window.open('https://retrospectivewiki.org/index.php?title=The_Prime_Directive', '_blank'); }} text="Open Retrospective Wiki Page" />
                               <PrimaryButton onClick={() => { this.setState({ isPrimeDirectiveDialogHidden: true }); }} text="Close" />
                             </DialogFooter>
-                        </Dialog>
-                        <TooltipHost
-                          hostClassName="toggle-carousel-button-tooltip-wrapper"
-                          content="Prime Directive"
-                          calloutProps={{ gapSpace: 0 }}>
-                          <ActionButton
-                            className="toggle-carousel-button"
-                            text="Prime Directive"
-                            iconProps={{ iconName: 'BookAnswers' }}
-                            onClick={() => { this.setState({ isPrimeDirectiveDialogHidden: false }); }}>
-                          </ActionButton>
-                        </TooltipHost>
-                      </>
+                          </Dialog>
+                          <TooltipHost
+                            hostClassName="toggle-carousel-button-tooltip-wrapper"
+                            content="Prime Directive"
+                            calloutProps={{ gapSpace: 0 }}>
+                            <ActionButton
+                              className="toggle-carousel-button"
+                              text="Prime Directive"
+                              iconProps={{ iconName: 'BookAnswers' }}
+                              onClick={() => { this.setState({ isPrimeDirectiveDialogHidden: false }); }}>
+                            </ActionButton>
+                          </TooltipHost>
+                        </>
                       }
                       <WorkflowStage
                         display="Collect"
@@ -1347,16 +1346,16 @@ export interface FeedbackBoardContainerState {
                               className="info-message-bar-action-spinner" />}
                           {!this.state.isReconnectingToBackendService &&
                             <>
-                            <MessageBarButton
-                              className="info-message-bar-action-button"
-                              onClick={this.tryReconnectToBackend}
-                              disabled={this.state.isReconnectingToBackendService}
-                              text="Reconnect" />
-                            <IconButton
-                              className="info-message-bar-action-button"
-                              onClick={() => { this.setState({ isBackendServiceConnected: true }) }}
-                              disabled={this.state.isReconnectingToBackendService}
-                              title="Hide">
+                              <MessageBarButton
+                                className="info-message-bar-action-button"
+                                onClick={this.tryReconnectToBackend}
+                                disabled={this.state.isReconnectingToBackendService}
+                                text="Reconnect" />
+                              <IconButton
+                                className="info-message-bar-action-button"
+                                onClick={() => { this.setState({ isBackendServiceConnected: true }) }}
+                                disabled={this.state.isReconnectingToBackendService}
+                                title="Hide">
                                 <span className="ms-Button-icon"><i className="fas fa-times"></i></span>
                               </IconButton>
                             </>
@@ -1381,6 +1380,7 @@ export interface FeedbackBoardContainerState {
                         this.state.currentBoard.activePhase == WorkflowPhase.Collect && this.state.currentBoard.shouldShowFeedbackAfterCollect :
                         false
                       }
+                      //hideFeedbackItems={true}
                       userId={this.state.currentUserId}
                     />
                   </div>
@@ -1463,19 +1463,19 @@ export interface FeedbackBoardContainerState {
             containerClassName: 'retrospectives-retro-summary-dialog',
             className: 'retrospectives-dialog-modal',
           }}>
-            { this.state.currentBoard &&
+          {this.state.currentBoard &&
             <>
               <div>Retrospective session date is {new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' }).format(this.state.currentBoard.startDate)}</div>
               <div>{this.state.feedbackItems.length} feedback items created</div>
               <div>{this.state.members.length} people in the team, {this.state.contributors.length} participants contributed</div>
-              <div>{Object.keys(this.state.currentBoard?.boardVoteCollection || {}).length} participants casted { this.state.castedVoteCount } votes</div>
+              <div>{Object.keys(this.state.currentBoard?.boardVoteCollection || {}).length} participants casted {this.state.castedVoteCount} votes</div>
               <div>{this.state.actionItemIds.length} action items created</div>
               <div>Board created by <img className="avatar" src={this.state.currentBoard?.createdBy.imageUrl} /> {this.state.currentBoard?.createdBy.displayName}</div>
               <div>
                 Effectiveness Scores:
-                { this.state.effectivenessMeasurementSummary.map((measurement, index) => {
-                    return <div key={index}>{measurement.question}: {measurement.average}</div>
-                  })
+                {this.state.effectivenessMeasurementSummary.map((measurement, index) => {
+                  return <div key={index}>{measurement.question}: {measurement.average}</div>
+                })
                 }
               </div>
               {!this.state.currentBoard.isAnonymous ?
@@ -1485,12 +1485,12 @@ export interface FeedbackBoardContainerState {
                     <div key={index}>
                       <img className="avatar" src={contributor.imageUrl} /> {contributor.name}
                     </div>
-                    )}
+                  )}
                 </>
-              : <div>Board is anonymous</div>}
-              { this.state.currentBoard.isAnonymous && <div>Retrospective was Anonymous</div> }
-              </>
-            }
+                : <div>Board is anonymous</div>}
+              {this.state.currentBoard.isAnonymous && <div>Retrospective was Anonymous</div>}
+            </>
+          }
         </Dialog>
         <Dialog
           hidden={this.state.isTeamBoardDeletedInfoDialogHidden}

--- a/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataForm.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataForm.tsx
@@ -74,15 +74,15 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
     this.state = {
       columnCardBeingEdited: undefined,
       columnCards: this.props.isNewBoardCreation ?
-      defaultColumnCards :
-      this.props.currentBoard.columns.map((column) => {
-        return {
-          // Need a deep copy of the column object here to avoid making changes to the original column.
-          // This ensures no changes are made when the user hits Cancel.
-          column: { ...column },
-          markedForDeletion: false,
-        };
-      }),
+        defaultColumnCards :
+        this.props.currentBoard.columns.map((column) => {
+          return {
+            // Need a deep copy of the column object here to avoid making changes to the original column.
+            // This ensures no changes are made when the user hits Cancel.
+            column: { ...column },
+            markedForDeletion: false,
+          };
+        }),
       isIncludeTeamEffectivenessMeasurement: this.props.isNewBoardCreation ? false : (this.props.currentBoard.isIncludeTeamEffectivenessMeasurement ? this.props.currentBoard.isIncludeTeamEffectivenessMeasurement : false),
       isBoardAnonymous: this.props.isNewBoardCreation ? false : (this.props.currentBoard.isAnonymous ? this.props.currentBoard.isAnonymous : false),
       maxVotesPerUser: this.props.isNewBoardCreation ? 5 : this.props.currentBoard.maxVotesPerUser,
@@ -94,17 +94,17 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
       selectedAccentColorKey: undefined,
       selectedIconKey: undefined,
       displayPrimeDirective: this.props.isNewBoardCreation ?
-      false :
-      (
-        this.props.currentBoard.displayPrimeDirective ?
-        this.props.currentBoard.displayPrimeDirective : false
-      ),
+        false :
+        (
+          this.props.currentBoard.displayPrimeDirective ?
+            this.props.currentBoard.displayPrimeDirective : false
+        ),
       shouldShowFeedbackAfterCollect: this.props.isNewBoardCreation ?
-      false :
-      (
-        this.props.currentBoard.shouldShowFeedbackAfterCollect ?
-        this.props.currentBoard.shouldShowFeedbackAfterCollect : false
-      ),
+        false :
+        (
+          this.props.currentBoard.shouldShowFeedbackAfterCollect ?
+            this.props.currentBoard.shouldShowFeedbackAfterCollect : false
+        ),
       title: this.props.initialValue
     };
   }
@@ -138,7 +138,7 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
 
       return;
     }
-console.log(this.state);
+    console.log(this.state);
     this.props.onFormSubmit(
       this.state.title.trim(),
       this.state.maxVotesPerUser,
@@ -147,7 +147,7 @@ console.log(this.state);
       this.state.isBoardAnonymous,
       this.state.shouldShowFeedbackAfterCollect,
       this.state.displayPrimeDirective
-     );
+    );
   }
 
   private handleIsIncludeTeamEffectivenessMeasurementCheckboxChange = (ev: React.MouseEvent<HTMLElement>, checked: boolean) => {
@@ -566,7 +566,7 @@ console.log(this.state);
         });
         break;
       default:
-      break;
+        break;
     }
   };
 
@@ -708,7 +708,7 @@ console.log(this.state);
 
           <div className="board-metadata-form-section-subheader">
             <Checkbox
-              label="Only show feedback after Collect phase"
+              label="Obscure the feedback of others until after Collect phase."
               ariaLabel="Only show feedback after Collect phase. This selection cannot be modified after board creation."
               boxSide="start"
               defaultChecked={this.state.shouldShowFeedbackAfterCollect}
@@ -745,7 +745,7 @@ console.log(this.state);
           </div>
 
           <div className="board-metadata-form-section-header">
-            Max Votes per User (Current:{this.props.isNewBoardCreation? 5 : this.props.currentBoard.maxVotesPerUser}) :
+            Max Votes per User (Current:{this.props.isNewBoardCreation ? 5 : this.props.currentBoard.maxVotesPerUser}) :
             <TextField className="title-input-container" type="number" min="3" max="12" value={this.state.maxVotesPerUser?.toString()} onChange={this.handleMaxVotePerUserChange} />
           </div>
         </div>
@@ -767,8 +767,8 @@ console.log(this.state);
               <option value="wlai">WentWell-Learned-Accelerators-Impediments</option>
             </select>
           </div>
-          { !this.props.isNewBoardCreation &&
-          <div className="board-metadata-form-section-subheader" style={{ fontSize:"12px", color:"#f6a608" }}>Warning: Existing feedbacks may not be available after changing board template!</div>
+          {!this.props.isNewBoardCreation &&
+            <div className="board-metadata-form-section-subheader" style={{ fontSize: "12px", color: "#f6a608" }}>Warning: Existing feedbacks may not be available after changing board template!</div>
           }
           <List
             items={this.state.columnCards}
@@ -897,7 +897,7 @@ console.log(this.state);
                 });
               }}>
               Add new column
-          </ActionButton>
+            </ActionButton>
           </div>
         </div>
         <DialogFooter>

--- a/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataForm.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackBoardMetadataForm.tsx
@@ -138,7 +138,6 @@ class FeedbackBoardMetadataForm extends React.Component<IFeedbackBoardMetadataFo
 
       return;
     }
-    console.log(this.state);
     this.props.onFormSubmit(
       this.state.title.trim(),
       this.state.maxVotesPerUser,

--- a/RetrospectiveExtension.Frontend/components/feedbackColumn.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackColumn.tsx
@@ -150,7 +150,7 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
     return {
       id: columnItem.feedbackItem.id,
       title: columnItem.feedbackItem.title,
-      createdBy:  columnItem.feedbackItem.createdBy ? columnItem.feedbackItem.createdBy.displayName : null,
+      createdBy: columnItem.feedbackItem.createdBy ? columnItem.feedbackItem.createdBy.displayName : null,
       createdByProfileImage: columnItem.feedbackItem.createdBy ? columnItem.feedbackItem.createdBy._links.avatar.href : null,
       lastEditedDate: columnItem.feedbackItem.modifedDate ? columnItem.feedbackItem.modifedDate.toString() : '',
       upvotes: columnItem.feedbackItem.upvotes,
@@ -274,7 +274,7 @@ export default class FeedbackColumn extends React.Component<FeedbackColumnProps,
           {this.props.workflowPhase === WorkflowPhase.Collect &&
             <div className="create-container" aria-label="Create Feedback Item">
               <ActionButton iconProps={{ iconName: 'Add' }}
-                componentRef={(element: IButton) => {this.createFeedbackButton = element;}}
+                componentRef={(element: IButton) => { this.createFeedbackButton = element; }}
                 onClick={this.createEmptyFeedbackItem}
                 aria-label="Create Feedback Item"
                 className="create-button">

--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -773,6 +773,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
                   title={this.props.title}
                   isChangeEventRequired={false}
                   onSave={this.onDocumentCardTitleSave}
+                  isDisabled={hideFeedbackItems}
                 />}
                 {!this.props.isInteractable &&
                   <div

--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -131,7 +131,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
       searchTerm: '',
       searchedFeedbackItems: [],
       showVotedAnimation: false,
-      userVotes:"0",
+      userVotes: "0",
     };
 
     this.itemElement = null;
@@ -262,7 +262,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
   private setDisabledFeedbackItemDeletion = async (boardId: string, id: string) => {
     const feedbackItem = await itemDataService.getFeedbackItem(boardId, id);
     if (feedbackItem) {
-      this.setState({isDeletionDisabled: feedbackItem.upvotes > 0});
+      this.setState({ isDeletionDisabled: feedbackItem.upvotes > 0 });
     }
   }
 
@@ -365,7 +365,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
         text: 'Delete feedback',
         title: 'Delete feedback (disabled when there are active votes)',
       },
-      workflowPhases: [ WorkflowPhase.Collect, WorkflowPhase.Group, WorkflowPhase.Vote, WorkflowPhase.Act ],
+      workflowPhases: [WorkflowPhase.Collect, WorkflowPhase.Group, WorkflowPhase.Vote, WorkflowPhase.Act],
     },
     {
       menuItem: {
@@ -375,7 +375,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
         text: 'Move feedback to different column',
         title: 'Move feedback to different column',
       },
-      workflowPhases: [ WorkflowPhase.Group ],
+      workflowPhases: [WorkflowPhase.Group],
       hideMobile: true,
     },
     {
@@ -386,7 +386,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
         text: 'Group feedback',
         title: 'Group feedback',
       },
-      workflowPhases: [ WorkflowPhase.Group ],
+      workflowPhases: [WorkflowPhase.Group],
       hideMobile: true,
     },
     {
@@ -397,13 +397,13 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
         text: 'Remove feedback from group',
         title: 'Remove feedback from group',
       },
-      workflowPhases: [ WorkflowPhase.Group ],
+      workflowPhases: [WorkflowPhase.Group],
       hideMobile: true,
       hideMainItem: true,
     },
   ];
 
-  private onVote = async (feedbackItemId: string,  decrement: boolean=false) => {
+  private onVote = async (feedbackItemId: string, decrement: boolean = false) => {
     const updatedFeedbackItem = await itemDataService.updateVote(this.props.boardId, this.props.team.id, getUserIdentity().id, feedbackItemId, decrement);
     // TODO (enpolat) : appInsightsClient.trackEvent(TelemetryEvents.FeedbackItemUpvoted);
 
@@ -416,10 +416,10 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
     }
   }
 
-  private timerSwich =  async (feedbackItemId: string) =>
-  {
+
+  private timerSwich = async (feedbackItemId: string) => {
     let updatedFeedbackItem;
-    const boardId:string = this.props.boardId;
+    const boardId: string = this.props.boardId;
 
     // function to handle timer count update
     const incTimer = async () => {
@@ -471,9 +471,9 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
 
   private isVoted = async (
     feedbackItemId: string) => {
-      itemDataService.isVoted(this.props.boardId, getUserIdentity().id, feedbackItemId).then(result => {
-        this.setState({ userVotes: result });
-      })
+    itemDataService.isVoted(this.props.boardId, getUserIdentity().id, feedbackItemId).then(result => {
+      this.setState({ userVotes: result });
+    })
   }
 
   private removeFeedbackItem = (
@@ -606,7 +606,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
     const isMainItem = isNotGroupedItem || this.props.groupedItemProps.isMainItem;
     const groupItemsCount = this.props && this.props.groupedItemProps && this.props.groupedItemProps.groupedCount + 1;
     const ariaLabel = isNotGroupedItem ? 'Feedback item.' : (!isMainItem ? 'Feedback group item.' : 'Feedback group main item. Group has ' + groupItemsCount + ' items.');
-    const hideFeedbackItems = this.props.hideFeedbackItems && (this.props.createdBy ? this.props.userIdRef !== getUserIdentity().id : false);
+    const hideFeedbackItems = this.props.hideFeedbackItems && (this.props.userIdRef !== getUserIdentity().id);
     const curTimerState = this.props.timerState;
 
     return (
@@ -657,14 +657,14 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
                       'fa-chevron-right': !this.props.groupedItemProps.isGroupExpanded
                     })} />
                     {groupItemsCount} Items
-                </button>
+                  </button>
                 }
                 {showVotes && this.props.isInteractable &&
                   // Using standard button tag here due to no onAnimationEnd support in fabricUI
                   <button
                     title="Vote"
                     aria-live="polite"
-                    aria-label={'Click to vote On feedback. Current vote count is ' + this.props.upvotes}
+                    aria-label={'Click to vote on feedback. Current vote count is ' + this.props.upvotes}
                     tabIndex={0}
                     disabled={!isMainItem || !showVoteButton || this.state.showVotedAnimation}
                     className={classNames(
@@ -690,7 +690,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
                   <button
                     title="UnVote"
                     aria-live="polite"
-                    aria-label={'Click to unvote On feedback. Current vote count is ' + this.props.upvotes}
+                    aria-label={'Click to unvote on feedback. Current vote count is ' + this.props.upvotes}
                     tabIndex={0}
                     disabled={!isMainItem || !showVoteButton || this.state.showVotedAnimation}
                     className={classNames(
@@ -708,7 +708,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
                       this.setState({ showVotedAnimation: false });
                     }}>
                     <i className="fas fa-arrow-circle-down" />
-                    
+
                   </button>
                 }
                 {!this.props.newlyCreated && this.props.isInteractable &&
@@ -811,23 +811,23 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
             </div>
             <div id="actionTimer" className="card-action-timer">
               {showAddActionItem &&
-              <button
-                title="Timer"
-                aria-live="polite"
-                aria-label={'Start/stop'}
-                tabIndex={0}
-                className={classNames(
-                  'feedback-action-button',
-                )}
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  this.timerSwich(this.props.id);
-                }}
-              >
-                <i className={curTimerState ? "fa fa-stop-circle": "fa fa-play-circle"} />
-                <span>  {this.props.timerSecs} (seconds)</span>
-              </button>
+                <button
+                  title="Timer"
+                  aria-live="polite"
+                  aria-label={'Start/stop'}
+                  tabIndex={0}
+                  className={classNames(
+                    'feedback-action-button',
+                  )}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    this.timerSwich(this.props.id);
+                  }}
+                >
+                  <i className={curTimerState ? "fa fa-stop-circle" : "fa fa-play-circle"} />
+                  <span>  {this.props.timerSecs} (seconds)</span>
+                </button>
               }
             </div>
           </DocumentCard>

--- a/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
+++ b/RetrospectiveExtension.Frontend/components/feedbackItem.tsx
@@ -416,7 +416,6 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
     }
   }
 
-
   private timerSwich = async (feedbackItemId: string) => {
     let updatedFeedbackItem;
     const boardId: string = this.props.boardId;
@@ -664,7 +663,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
                   <button
                     title="Vote"
                     aria-live="polite"
-                    aria-label={'Click to vote on feedback. Current vote count is ' + this.props.upvotes}
+                    aria-label={'Click to vote On feedback. Current vote count is ' + this.props.upvotes}
                     tabIndex={0}
                     disabled={!isMainItem || !showVoteButton || this.state.showVotedAnimation}
                     className={classNames(
@@ -690,7 +689,7 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
                   <button
                     title="UnVote"
                     aria-live="polite"
-                    aria-label={'Click to unvote on feedback. Current vote count is ' + this.props.upvotes}
+                    aria-label={'Click to unvote On feedback. Current vote count is ' + this.props.upvotes}
                     tabIndex={0}
                     disabled={!isMainItem || !showVoteButton || this.state.showVotedAnimation}
                     className={classNames(
@@ -773,7 +772,6 @@ class FeedbackItem extends React.Component<IFeedbackItemProps, IFeedbackItemStat
                   title={this.props.title}
                   isChangeEventRequired={false}
                   onSave={this.onDocumentCardTitleSave}
-                  isDisabled={hideFeedbackItems}
                 />}
                 {!this.props.isInteractable &&
                   <div

--- a/RetrospectiveExtension.Frontend/css/mobile/mobileFeedbackItem.scss
+++ b/RetrospectiveExtension.Frontend/css/mobile/mobileFeedbackItem.scss
@@ -3,6 +3,11 @@
 .feedbackItem {
   flex-basis: 100%;
 
+  &.hideFeedbackItem .card-content {
+    filter: blur(15px);
+    pointer-events: none;
+  }
+
   .mainItemCard {
     min-width: calc(100vw - 45px);
     max-width: calc(100vw - 45px);
@@ -10,7 +15,7 @@
     .card-integral-part {
       .card-header {
         height: $mobile_feedback_item_header_height;
-  
+
         .feedback-action-button {
           height: 65px;
           min-width: $mobile_feedback_item_action_button_width;
@@ -19,7 +24,7 @@
           margin-left: 15px;
           margin-top: 10px;
           padding: 1px 7px;
-  
+
           i {
             height: 65px;
             line-height: 1.3;
@@ -47,7 +52,7 @@
           .contextual-menu-button {
             height: 60px;
             width: 45px;
-  
+
             i {
               height: 65px;
               width: 45px;


### PR DESCRIPTION
Worked with @nexilus18 

Addresses [#123](https://github.com/microsoft/vsts-extension-retrospectives/issues/123)

Fixes the bug that even when a retrospective is set up to be anonymous and "hide feedback until after collect" has been selected, the feedback items made by others are still visible. This obscuring is via a CSS blur, so for accessibility, the aria-label indicates it is not visible during collection. Once the user switches to a different phase then all feedback items are visible.

(Also adds image descriptions to the screenshots in the README since I was there anyway.) ♿ 
