### PR TITLE
[Task 1469] Add basic rendering tests for boardSummary component

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,8 @@ necessary (including bug fixes) and include these tests in your pull requests.
 
 To run tests in "watch" mode, as you make changes to components, run `npm run test:watch`.
 
+To automatically generate the test coverage report, add the `--coverage` flag to the `test` script defined in [package.json](RetrospectiveExtension.Frontend/package.json). After the test run is completed, coverage statistics will then be reported in the newly created `coverage` directory.
+
 #### Mocks
 
 In order to simulate API calls and some external module functionality, jest mocks were created and utilized. Mocks that

--- a/RetrospectiveExtension.Frontend/components/__mocks__/WorkflowStage.tsx
+++ b/RetrospectiveExtension.Frontend/components/__mocks__/WorkflowStage.tsx
@@ -1,6 +1,6 @@
 export const mockWorkflowStage = {
-    display: 'test',
-    value: 'Collect',
-    isActive: true,
-    clickEventCallback: () => {}
+  display: 'test',
+  value: 'Collect',
+  isActive: true,
+  clickEventCallback: () => {}
 };

--- a/RetrospectiveExtension.Frontend/components/__mocks__/azure-devops-extension-api/Common/Common.tsx
+++ b/RetrospectiveExtension.Frontend/components/__mocks__/azure-devops-extension-api/Common/Common.tsx
@@ -1,3 +1,3 @@
 export const mockCommon = {
-    getClient: () => {},
+  getClient: () => {},
 };

--- a/RetrospectiveExtension.Frontend/components/__mocks__/azure-devops-extension-api/Core/Core.tsx
+++ b/RetrospectiveExtension.Frontend/components/__mocks__/azure-devops-extension-api/Core/Core.tsx
@@ -1,5 +1,5 @@
 export const mockCore = {
-    CoreRestClient: {
-        RESOURCE_AREA_ID: "resourceAreaId",
-    }
+  CoreRestClient: {
+    RESOURCE_AREA_ID: "resourceAreaId",
+  }
 };

--- a/RetrospectiveExtension.Frontend/components/__mocks__/azure-devops-extension-sdk/sdk.tsx
+++ b/RetrospectiveExtension.Frontend/components/__mocks__/azure-devops-extension-sdk/sdk.tsx
@@ -1,45 +1,45 @@
 const CommonServiceIds = {
-    ExtensionDataService: "ms.vss-features.extension-data-service",
-    GlobalMessagesService: "ms.vss-tfs-web.tfs-global-messages-service",
-    HostNavigationService: "ms.vss-features.host-navigation-service",
-    HostPageLayoutService: "ms.vss-features.host-page-layout-service",
-    LocationService: "ms.vss-features.location-service",
-    ProjectPageService: "ms.vss-tfs-web.tfs-page-data-service"
+  ExtensionDataService: "ms.vss-features.extension-data-service",
+  GlobalMessagesService: "ms.vss-tfs-web.tfs-global-messages-service",
+  HostNavigationService: "ms.vss-features.host-navigation-service",
+  HostPageLayoutService: "ms.vss-features.host-page-layout-service",
+  LocationService: "ms.vss-features.location-service",
+  ProjectPageService: "ms.vss-tfs-web.tfs-page-data-service"
 };
 
 const mockExtensionDataService = {
-    getExtensionDataManager: () => {},
+  getExtensionDataManager: () => {},
 };
 
 const mockLocationService = {
-    getResourceAreaLocation: () => {return 'https://hosturl'},
+  getResourceAreaLocation: () => {return 'https://hosturl'},
 };
 
 const mockProjectPageService = {
-    getProject: () => {
-        return {
-        id: "id",
-        name: "name",
-        };
-    },
+  getProject: () => {
+    return {
+    id: "id",
+    name: "name",
+    };
+  },
 };
 
 const mockUser = {id: "userId", };
 const mockExtensionContext = { id: "contextId", };
 const getServiceMock = (id:string) => {
-    if (id == CommonServiceIds.LocationService)
-        return mockLocationService;
-    else if (id == CommonServiceIds.ProjectPageService)
-        return mockProjectPageService;
-    else
-        return mockExtensionDataService;
+  if (id == CommonServiceIds.LocationService)
+    return mockLocationService;
+  else if (id == CommonServiceIds.ProjectPageService)
+    return mockProjectPageService;
+  else
+    return mockExtensionDataService;
 };
 
 const mockSdk = {
-    getService: getServiceMock,
-    getUser: () => { return mockUser },
-    getExtensionContext: () => { return mockExtensionContext },
-    getAccessToken: () => { return 'token' },
+  getService: getServiceMock,
+  getUser: () => { return mockUser },
+  getExtensionContext: () => { return mockExtensionContext },
+  getAccessToken: () => { return 'token' },
 };
 
 export const MockSDK = mockSdk;

--- a/RetrospectiveExtension.Frontend/components/__mocks__/config/environment.tsx
+++ b/RetrospectiveExtension.Frontend/components/__mocks__/config/environment.tsx
@@ -1,5 +1,5 @@
 export const mockEnv = {
-    CollaborationStateServiceUrl: "https://serviceurl",
-    CurrentEnvironment: process.env.NODE_ENV,
-    AppInsightsInstrumentKey:  'my_instrumentation_key' // put Instrumentation key here
+  CollaborationStateServiceUrl: "https://serviceurl",
+  CurrentEnvironment: process.env.NODE_ENV,
+  AppInsightsInstrumentKey:  'my_instrumentation_key' // put Instrumentation key here
 };

--- a/RetrospectiveExtension.Frontend/components/__tests__/boardSummary.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/boardSummary.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
+import { shallow, ShallowWrapper} from 'enzyme';
+import { DetailsList } from 'office-ui-fabric-react/lib/DetailsList';
 import { mockWorkItem, mockWorkItemType } from './mocked_components/WorkItemTracking';
-import { shallow, ShallowWrapper } from 'enzyme';
 import BoardSummary, { IBoardSummaryProps } from '../boardSummary';
 
 const mockedDefaultProps: IBoardSummaryProps = {
@@ -24,36 +25,46 @@ const mockedWorkItemCountProps: IBoardSummaryProps = {
 };
 
 describe('Board Summary', () => {
-  test('renders with no action or work items.', () => {
+  it('renders with no action or work items.', () => {
     const wrapper = shallow(<BoardSummary {...mockedDefaultProps} />);
     const component = wrapper.children().dive();
 
     verifySummaryBoardCounts(component, mockedDefaultProps);
+    verifyActionItemsSummaryCard(component, false);
   });
 
-  test('renders with one action item.', () => {
+  it('renders with one action item.', () => {
     mockedDefaultProps.actionItems.push(mockWorkItem);
     mockedDefaultProps.supportedWorkItemTypes.push(mockWorkItemType);
     const wrapper = shallow(<BoardSummary {...mockedDefaultProps} />);
     const component = wrapper.children().dive();
 
     verifySummaryBoardCounts(component, mockedDefaultProps);
+    verifyActionItemsSummaryCard(component, true);
   });
 
-  test('renders when work item counts are greater than zero.', () => {
+  it('renders when work item counts are greater than zero.', () => {
     const wrapper = shallow(<BoardSummary {...mockedWorkItemCountProps} />);
     const component = wrapper.children().dive();
 
     verifySummaryBoardCounts(component, mockedWorkItemCountProps);
+    verifyActionItemsSummaryCard(component, false);
   });
 
-  test('renders with one action item when work item counts are greater than zero.', () => {
+  it.skip('renders action item columns when an action item exists.', () => {
+    const wrapper = shallow(<BoardSummary {...mockedWorkItemCountProps} />);
+
+    console.log(wrapper.debug());
+  });
+
+  it('renders with one action item when work item counts are greater than zero.', () => {
     mockedWorkItemCountProps.actionItems.push(mockWorkItem);
     mockedWorkItemCountProps.supportedWorkItemTypes.push(mockWorkItemType);
     const wrapper = shallow(<BoardSummary {...mockedWorkItemCountProps} />);
     const component = wrapper.children().dive();
 
     verifySummaryBoardCounts(component, mockedWorkItemCountProps);
+    verifyActionItemsSummaryCard(component, true);
   });
 });
 
@@ -71,3 +82,13 @@ const verifySummaryBoardCounts = (component: ShallowWrapper, props: IBoardSummar
     child => child.prop("aria-label") === "resolved work items count").text()).toBe(
       props.resolvedActionItemsCount.toString());
 };
+
+const verifyActionItemsSummaryCard = (component: ShallowWrapper, wereActionItemsInclude: boolean) => {
+  if(wereActionItemsInclude){
+    const child = component.findWhere((child: any) => child.prop('className') === 'action-items-summary-card').children();
+    expect(child.find(DetailsList)).toHaveLength(1);
+  } else {
+    expect(component.findWhere((child: any) => child.prop('className') === 'action-items-summary-card').
+      text()).toBe('Looks like no work items were created for this board.');
+  }
+}

--- a/RetrospectiveExtension.Frontend/components/__tests__/boardSummary.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/boardSummary.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shallow, mount, ShallowWrapper} from 'enzyme';
+import { shallow, ShallowWrapper} from 'enzyme';
 import { DetailsList } from 'office-ui-fabric-react/lib/DetailsList';
 import { mockWorkItem, mockWorkItemType } from './mocked_components/WorkItemTracking';
 import BoardSummary, { IBoardSummaryProps } from '../boardSummary';
@@ -51,12 +51,6 @@ describe('Board Summary', () => {
     verifyActionItemsSummaryCard(component, false);
   });
 
-  it.skip('renders action item columns when an action item exists.', () => {
-    const wrapper = mount(<BoardSummary {...mockedWorkItemCountProps} />);
-
-    console.log(wrapper.debug());
-  });
-
   it('renders with one action item when work item counts are greater than zero.', () => {
     mockedWorkItemCountProps.actionItems.push(mockWorkItem);
     mockedWorkItemCountProps.supportedWorkItemTypes.push(mockWorkItemType);
@@ -85,9 +79,11 @@ const verifySummaryBoardCounts = (component: ShallowWrapper, props: IBoardSummar
 
 const verifyActionItemsSummaryCard = (component: ShallowWrapper, wereActionItemsInclude: boolean) => {
   if(wereActionItemsInclude){
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const child = component.findWhere((child: any) => child.prop('className') === 'action-items-summary-card').children();
     expect(child.find(DetailsList)).toHaveLength(1);
   } else {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(component.findWhere((child: any) => child.prop('className') === 'action-items-summary-card').
       text()).toBe('Looks like no work items were created for this board.');
   }

--- a/RetrospectiveExtension.Frontend/components/__tests__/boardSummary.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/boardSummary.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shallow, ShallowWrapper} from 'enzyme';
+import { shallow, mount, ShallowWrapper} from 'enzyme';
 import { DetailsList } from 'office-ui-fabric-react/lib/DetailsList';
 import { mockWorkItem, mockWorkItemType } from './mocked_components/WorkItemTracking';
 import BoardSummary, { IBoardSummaryProps } from '../boardSummary';
@@ -52,7 +52,7 @@ describe('Board Summary', () => {
   });
 
   it.skip('renders action item columns when an action item exists.', () => {
-    const wrapper = shallow(<BoardSummary {...mockedWorkItemCountProps} />);
+    const wrapper = mount(<BoardSummary {...mockedWorkItemCountProps} />);
 
     console.log(wrapper.debug());
   });

--- a/RetrospectiveExtension.Frontend/components/__tests__/boardSummary.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/boardSummary.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, ShallowWrapper } from 'enzyme';
 import BoardSummary, { IBoardSummaryProps } from '../boardSummary';
 import { WorkItem, WorkItemType } from '../__mocks__/azure-devops-extension-api/WorkItemTracking/WorkItemTracking';
 
@@ -13,20 +13,43 @@ const mockedDefaultProps: IBoardSummaryProps = {
   supportedWorkItemTypes: []
 };
 
+const mockedWorkItemCountProps: IBoardSummaryProps = {
+  actionItems: [],
+  isDataLoaded: false,
+  pendingWorkItemsCount: 2,
+  resolvedActionItemsCount: 3,
+  boardName: '',
+  feedbackItemsCount: 8,
+  supportedWorkItemTypes: []
+};
+
 describe('Board Summary', () => {
   test('renders with no action or work items.', () => {
     const wrapper = shallow(<BoardSummary {...mockedDefaultProps} />);
     const component = wrapper.children().dive();
 
-    console.log(component.debug());
+    verifySummaryBoardCounts(component, mockedDefaultProps);
+  });
 
-    expect(component.findWhere(
-      child => child.prop("aria-label") === "feedback item count").text()).toBe(0);
-    expect(component.findWhere(
-      child => child.prop("aria-label") === "total work items count").text()).toBe(0);
-    expect(component.findWhere(
-      child => child.prop("aria-label") === "pending work items count").text()).toBe(0);
-    expect(component.findWhere(
-      child => child.prop("aria-label") === "resolved work items count").text()).toBe(0);
+  test('renders with when work item counts are greater than zero.', () => {
+    const wrapper = shallow(<BoardSummary {...mockedWorkItemCountProps} />);
+    const component = wrapper.children().dive();
+
+    verifySummaryBoardCounts(component, mockedWorkItemCountProps);
   });
 });
+
+const verifySummaryBoardCounts = (component: ShallowWrapper, props: IBoardSummaryProps) => {
+  expect(component.findWhere(
+    child => child.prop("aria-label") === "feedback item count").text()).toBe(
+      props.feedbackItemsCount.toString());
+  expect(component.findWhere(
+    child => child.prop("aria-label") === "total work items count").text()).toBe(
+      (props.actionItems.length).toString());
+  expect(component.findWhere(
+    child => child.prop("aria-label") === "pending work items count").text()).toBe(
+      props.pendingWorkItemsCount.toString());
+  expect(component.findWhere(
+    child => child.prop("aria-label") === "resolved work items count").text()).toBe(
+      props.resolvedActionItemsCount.toString());
+};

--- a/RetrospectiveExtension.Frontend/components/__tests__/boardSummary.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/boardSummary.test.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
+import { mockWorkItem, mockWorkItemType } from './mocked_components/WorkItemTracking';
 import { shallow, ShallowWrapper } from 'enzyme';
 import BoardSummary, { IBoardSummaryProps } from '../boardSummary';
-import { WorkItem, WorkItemType } from '../__mocks__/azure-devops-extension-api/WorkItemTracking/WorkItemTracking';
 
 const mockedDefaultProps: IBoardSummaryProps = {
   actionItems: [],
-  isDataLoaded: false,
+  isDataLoaded: true,
   pendingWorkItemsCount: 0,
   resolvedActionItemsCount: 0,
   boardName: '',
@@ -31,7 +31,25 @@ describe('Board Summary', () => {
     verifySummaryBoardCounts(component, mockedDefaultProps);
   });
 
-  test('renders with when work item counts are greater than zero.', () => {
+  test('renders with one action item.', () => {
+    mockedDefaultProps.actionItems.push(mockWorkItem);
+    mockedDefaultProps.supportedWorkItemTypes.push(mockWorkItemType);
+    const wrapper = shallow(<BoardSummary {...mockedDefaultProps} />);
+    const component = wrapper.children().dive();
+
+    verifySummaryBoardCounts(component, mockedDefaultProps);
+  });
+
+  test('renders when work item counts are greater than zero.', () => {
+    const wrapper = shallow(<BoardSummary {...mockedWorkItemCountProps} />);
+    const component = wrapper.children().dive();
+
+    verifySummaryBoardCounts(component, mockedWorkItemCountProps);
+  });
+
+  test('renders with one action item when work item counts are greater than zero.', () => {
+    mockedWorkItemCountProps.actionItems.push(mockWorkItem);
+    mockedWorkItemCountProps.supportedWorkItemTypes.push(mockWorkItemType);
     const wrapper = shallow(<BoardSummary {...mockedWorkItemCountProps} />);
     const component = wrapper.children().dive();
 

--- a/RetrospectiveExtension.Frontend/components/__tests__/boardSummary.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/boardSummary.test.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import BoardSummary, { IBoardSummaryProps } from '../boardSummary';
+import { WorkItem, WorkItemType } from '../__mocks__/azure-devops-extension-api/WorkItemTracking/WorkItemTracking';
+
+const mockedDefaultProps: IBoardSummaryProps = {
+  actionItems: [],
+  isDataLoaded: false,
+  pendingWorkItemsCount: 0,
+  resolvedActionItemsCount: 0,
+  boardName: '',
+  feedbackItemsCount: 0,
+  supportedWorkItemTypes: []
+};
+
+describe('Board Summary', () => {
+  test('renders with no action or work items.', () => {
+    const wrapper = shallow(<BoardSummary {...mockedDefaultProps} />);
+    const component = wrapper.children().dive();
+
+    console.log(component.debug());
+
+    expect(component.findWhere(
+      child => child.prop("aria-label") === "feedback item count").text()).toBe(0);
+    expect(component.findWhere(
+      child => child.prop("aria-label") === "total work items count").text()).toBe(0);
+    expect(component.findWhere(
+      child => child.prop("aria-label") === "pending work items count").text()).toBe(0);
+    expect(component.findWhere(
+      child => child.prop("aria-label") === "resolved work items count").text()).toBe(0);
+  });
+});

--- a/RetrospectiveExtension.Frontend/components/__tests__/feedbackBoardContainer.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/feedbackBoardContainer.test.tsx
@@ -9,5 +9,7 @@ const feedbackBoardContainerProps: FeedbackBoardContainerProps = {
 };
 
 describe(`The Feedback Board Component`, () => {
-  it("Renders a Feedback Board Container Component", () => {});
+  it("Renders a Feedback Board Container Component", () => {
+    console.log(feedbackBoardContainerProps);
+  });
 });

--- a/RetrospectiveExtension.Frontend/components/__tests__/feedbackItem.test.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/feedbackItem.test.tsx
@@ -44,7 +44,7 @@ const testGroupedItemProps = mocked({
   isGroupExpanded: false,
   isMainItem: true,
   parentItemId: '',
-  setIsGroupBeingDragged: jest.fn((isBeingDragged) => { }),
+  setIsGroupBeingDragged: jest.fn(() => { }),
   toggleGroupExpand: jest.fn(() => {}),
   updateGroupCardStackHeight: jest.fn(() => {}),
 });
@@ -78,6 +78,7 @@ const testColumnItem = mocked({
 });
 
 const testColumnIds: string[] = [testColumnUuidOne, testColumnUuidTwo];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const testColumnsObj: any = {};
 testColumnsObj[testColumnUuidOne] = {
   columnProperties:
@@ -157,13 +158,9 @@ const testColumnProps = mocked({
   shouldFocusOnCreateFeedback: false,
   hideFeedbackItems: false,
   onVoteCasted: jest.fn(() => { }),
-  addFeedbackItems: jest.fn((
-    columnId, columnItems, shouldBroadcast, newlyCreated, showAddedAnimation, shouldHaveFocus, hideFeedbackItems) => {
-
-  }),
-  removeFeedbackItemFromColumn: jest.fn((
-    columnIdToDeleteFrom, feedbackItemIdToDelete, shouldSetFocusOnFirstAvailableItem) => { }),
-  refreshFeedbackItems: jest.fn((feedbackItems, shouldBroadcast) => { }),
+  addFeedbackItems: jest.fn(() => {}),
+  removeFeedbackItemFromColumn: jest.fn(() => {}),
+  refreshFeedbackItems: jest.fn(() => { }),
 });
 
 describe('Feedback Item', () => {

--- a/RetrospectiveExtension.Frontend/components/__tests__/mocked_components/WorkItemTracking.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/mocked_components/WorkItemTracking.tsx
@@ -51,7 +51,11 @@ export const mockWorkItem = mocked({
   commentVersionRef: WorkItemCommentVersionRef,
   fields: {
     ['System.WorkItemType'] : 'Test Work Item Type Name',
-    ['System.AssignedTo'] : 'Jane Doe'
+    ['System.ChangedDate'] : (new Date()).toLocaleDateString(),
+    ['System.AssignedTo'] : 'Jane Doe',
+    ['System.Title'] : 'Mocked Work Item Title',
+    ['System.State'] : 'Resolved',
+    ['Microsoft.VSTS.Common.Priority'] : 'high'
   },
   id: 500,
   relations: [WorkItemRelation],

--- a/RetrospectiveExtension.Frontend/components/__tests__/mocked_components/WorkItemTracking.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/mocked_components/WorkItemTracking.tsx
@@ -1,0 +1,77 @@
+import { mocked } from 'jest-mock';
+
+const WorkItemFieldReference = {
+  name: 'Test Work Item Field Reference Name',
+  referenceName: 'Test Work Item Field Reference Ref',
+  url: 'https://workitemfieldrefurl',
+}
+
+const WorkItemTypeFieldInstance = {
+  allowedValues: ['Type 1', 'Type 2', 'Type 3'],
+  defaultValue: 'Default Work Item Type Field value',
+  alwaysRequired: false,
+  dependentFields: [WorkItemFieldReference],
+  helpText: 'Test Work Item Type Help Text',
+  name: 'Test Work Item Type Field Name',
+  referenceName: 'Test Work Item Type Field Reference Name',
+  url: 'https://workitemtypefieldurl',
+}
+
+const WorkItemIcon = {
+  id: 'TestWorkItemIconId',
+  url: 'https://workitemiconurl',
+}
+
+const WorkItemStateColor = {
+  category: 'Test State Category',
+  color: '#008080',
+  name: 'Test State Name',
+}
+
+const WorkItemStateTransition = {
+  actions: ['action 1', 'action 2', 'action 3'],
+  to: 'action 2',
+}
+const WorkItemCommentVersionRef = {
+  commentId: 4,
+  createdInRevision: 1,
+  isDeleted: false,
+  text: 'Test Work Item Comment Version Text',
+  version: 1,
+  url: 'https://workitemcommenturl'
+}
+
+const WorkItemRelation = {
+  attributes: { ['Test attribute'] : '' },
+  rel: 'Test relation',
+  url: 'https://workitemrelationurl',
+}
+
+export const mockWorkItem = mocked({
+  commentVersionRef: WorkItemCommentVersionRef,
+  fields: {
+    ['System.WorkItemType'] : 'Test Work Item Type Name',
+    ['System.AssignedTo'] : 'Jane Doe'
+  },
+  id: 500,
+  relations: [WorkItemRelation],
+  rev: 2,
+  _links: ['link 1'],
+  url: 'https://workitemurl'
+});
+
+export const mockWorkItemType = mocked({
+  color: '#4B0082',
+  description: 'Test Work Item Type Description',
+  fieldInstances: [WorkItemTypeFieldInstance],
+  fields: [WorkItemTypeFieldInstance],
+  icon: WorkItemIcon,
+  isDisabled: false,
+  name: 'Test Work Item Type Name',
+  referenceName: 'Test Work Item Type Reference Name',
+  states: [WorkItemStateColor],
+  transitions: { ['test transition'] : [WorkItemStateTransition] },
+  xmlForm: '<samplexml>Test XML Form</samplexml>',
+  url: 'https://workitemtypeurl',
+  _links: ['link 1'],
+});

--- a/RetrospectiveExtension.Frontend/components/__tests__/setupTests.tsx
+++ b/RetrospectiveExtension.Frontend/components/__tests__/setupTests.tsx
@@ -1,5 +1,5 @@
 import Enzyme from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import { mockEnv } from '../__mocks__/config/environment';
 import { mockCore } from '../__mocks__/azure-devops-extension-api/Core/Core';
 import { mockCommon } from '../__mocks__/azure-devops-extension-api/Common/Common';

--- a/RetrospectiveExtension.Frontend/dal/dataService.tsx
+++ b/RetrospectiveExtension.Frontend/dal/dataService.tsx
@@ -24,6 +24,7 @@ export async function readDocuments<T>(
 
   try {
     data = await dataService.getDocuments(collectionName, isPrivate ? { scopeType: 'User' } : undefined);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {
     if (e.serverError.typeKey === 'DocumentCollectionDoesNotExistException') {
       if (throwCollectionDoesNotExistException) {

--- a/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
+++ b/RetrospectiveExtension.Frontend/dal/itemDataService.tsx
@@ -62,6 +62,7 @@ class ItemDataService {
 
     try {
       feedbackItems = await ExtensionDataService.readDocuments<IFeedbackItemDocument>(boardId, false, true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       if (e.serverError.typeKey === 'DocumentCollectionDoesNotExistException') {
         // TODO (enpolat) : appInsightsClient.trackTrace(TelemetryExceptions.ItemsNotFoundForBoard, e, AI.SeverityLevel.Warning);

--- a/RetrospectiveExtension.Frontend/package-lock.json
+++ b/RetrospectiveExtension.Frontend/package-lock.json
@@ -1861,6 +1861,40 @@
       "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
       "dev": true
     },
+    "@wojtekmaj/enzyme-adapter-react-17": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-react-17/-/enzyme-adapter-react-17-0.6.6.tgz",
+      "integrity": "sha512-gSfhg8CiL0Vwc2UgUblGVZIy7M0KyXaZsd8+QwzV8TSVRLkGyzdLtYEcs9wRWyQTsdmOd+oRGqbVgUX7AVJxug==",
+      "dev": true,
+      "requires": {
+        "@wojtekmaj/enzyme-adapter-utils": "^0.1.2",
+        "enzyme-shallow-equal": "^1.0.0",
+        "has": "^1.0.0",
+        "prop-types": "^15.7.0",
+        "react-is": "^17.0.0",
+        "react-test-renderer": "^17.0.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        }
+      }
+    },
+    "@wojtekmaj/enzyme-adapter-utils": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@wojtekmaj/enzyme-adapter-utils/-/enzyme-adapter-utils-0.1.4.tgz",
+      "integrity": "sha512-ARGIQSIIv3oBia1m5Ihn1VU0FGmft6KPe39SBKTb8p7LSXO23YI4kNtc4M/cKoIY7P+IYdrZcgMObvedyjoSQA==",
+      "dev": true,
+      "requires": {
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.0",
+        "object.fromentries": "^2.0.0",
+        "prop-types": "^15.7.0"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -8568,6 +8602,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-shallow-renderer": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0"
+      }
+    },
     "react-slick": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/react-slick/-/react-slick-0.28.1.tgz",
@@ -8586,6 +8630,26 @@
       "integrity": "sha512-zO24J+1Qg2AHxtSNMfHeGW1dxFcmLJQrAeLJyCAENdNdwJt+YolDDtJEBdZlukon7rZeAdB3d5gUH6eb9Dn5Ug==",
       "requires": {
         "classnames": "^2.2.5"
+      }
+    },
+    "react-test-renderer": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+      "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^17.0.2",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        }
       }
     },
     "react-toastify": {

--- a/RetrospectiveExtension.Frontend/package-lock.json
+++ b/RetrospectiveExtension.Frontend/package-lock.json
@@ -1166,15 +1166,6 @@
         "@types/react": "*"
       }
     },
-    "@types/enzyme-adapter-react-16": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.6.tgz",
-      "integrity": "sha512-VonDkZ15jzqDWL8mPFIQnnLtjwebuL9YnDkqeCDYnB4IVgwUm0mwKkqhrxLL6mb05xm7qqa3IE95m8CZE9imCg==",
-      "dev": true,
-      "requires": {
-        "@types/enzyme": "*"
-      }
-    },
     "@types/eslint": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
@@ -2001,23 +1992,6 @@
         "indent-string": "^4.0.0"
       }
     },
-    "airbnb-prop-types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-      "dev": true,
-      "requires": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
-      }
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2352,17 +2326,6 @@
             "has-tostringtag": "^1.0.0"
           }
         }
-      }
-    },
-    "array.prototype.find": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.2.tgz",
-      "integrity": "sha512-00S1O4ewO95OmmJW7EesWfQlrCrLEL8kZ40w3+GkLX2yTt0m2ggcePPa2uHPJ9KUmJvwRq+lCV9bD8Yim23x/Q==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0"
       }
     },
     "array.prototype.flat": {
@@ -4177,62 +4140,6 @@
         "raf": "^3.4.1",
         "rst-selector-parser": "^2.2.3",
         "string.prototype.trim": "^1.2.1"
-      }
-    },
-    "enzyme-adapter-react-16": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.6.tgz",
-      "integrity": "sha512-yFlVJCXh8T+mcQo8M6my9sPgeGzj85HSHi6Apgf1Cvq/7EL/J9+1JoJmJsRxZgyTvPMAqOEpRSu/Ii/ZpyOk0g==",
-      "dev": true,
-      "requires": {
-        "enzyme-adapter-utils": "^1.14.0",
-        "enzyme-shallow-equal": "^1.0.4",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.2",
-        "object.values": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.13.1",
-        "react-test-renderer": "^16.0.0-0",
-        "semver": "^5.7.0"
-      },
-      "dependencies": {
-        "react-test-renderer": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
-          "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.8.6",
-            "scheduler": "^0.19.1"
-          }
-        },
-        "scheduler": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
-      }
-    },
-    "enzyme-adapter-utils": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.0.tgz",
-      "integrity": "sha512-F/z/7SeLt+reKFcb7597IThpDp0bmzcH1E9Oabqv+o01cID2/YInlqHbFl7HzWBl4h3OdZYedtwNDOmSKkk0bg==",
-      "dev": true,
-      "requires": {
-        "airbnb-prop-types": "^2.16.0",
-        "function.prototype.name": "^1.1.3",
-        "has": "^1.0.3",
-        "object.assign": "^4.1.2",
-        "object.fromentries": "^2.0.3",
-        "prop-types": "^15.7.2",
-        "semver": "^5.7.1"
       }
     },
     "enzyme-shallow-equal": {
@@ -8419,17 +8326,6 @@
         "react-is": "^16.13.1"
       }
     },
-    "prop-types-exact": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
-      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -8806,12 +8702,6 @@
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
       }
-    },
-    "reflect.ownkeys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
-      "dev": true
     },
     "regexp.prototype.flags": {
       "version": "1.4.1",

--- a/RetrospectiveExtension.Frontend/package.json
+++ b/RetrospectiveExtension.Frontend/package.json
@@ -12,7 +12,7 @@
     "publish:d": "npm run build && npm run pack:d && tfx extension publish --manifests vss-extension-dev.json --vsix ./dist/*.vsix",
     "publish:p": "npm run build && npm run pack:p && tfx extension publish --manifests vss-extension-prod.json --vsix ./dist/*.vsix",
     "start:dev": "webpack-dev-server --mode development",
-    "test": "jest --env=jsdom --silent -ci --coverage --testResultsProcessor=jest-junit",
+    "test": "jest --env=jsdom -ci --coverage --testResultsProcessor=jest-junit",
     "test:watch": "jest --env=jsdom --watch"
   },
   "repository": {
@@ -87,7 +87,8 @@
   },
   "jest": {
     "testPathIgnorePatterns": [
-      "./components/__tests__/setupTests.tsx"
+      "./components/__tests__/setupTests.tsx",
+      "./components/__tests__/mocked_components/*"
     ],
     "transform": {
       "^.+\\.(js|ts|tsx|jsx)$": "ts-jest"

--- a/RetrospectiveExtension.Frontend/package.json
+++ b/RetrospectiveExtension.Frontend/package.json
@@ -47,7 +47,6 @@
   "devDependencies": {
     "@types/classnames": "2.3.0",
     "@types/enzyme": "^3.10.11",
-    "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/file-saver": "2.0.5",
     "@types/jest": "^27.4.0",
     "@types/jsdom": "^16.2.14",
@@ -63,7 +62,6 @@
     "crypto-browserify": "3.12.0",
     "css-loader": "6.5.1",
     "enzyme": "^3.11.0",
-    "enzyme-adapter-react-16": "^1.15.6",
     "eslint": "8.6.0",
     "eslint-plugin-react": "7.28.0",
     "eslint-webpack-plugin": "3.1.1",

--- a/RetrospectiveExtension.Frontend/package.json
+++ b/RetrospectiveExtension.Frontend/package.json
@@ -12,7 +12,7 @@
     "publish:d": "npm run build && npm run pack:d && tfx extension publish --manifests vss-extension-dev.json --vsix ./dist/*.vsix",
     "publish:p": "npm run build && npm run pack:p && tfx extension publish --manifests vss-extension-prod.json --vsix ./dist/*.vsix",
     "start:dev": "webpack-dev-server --mode development",
-    "test": "jest --env=jsdom --silent -ci --coverage --testResultsProcessor=jest-junit",
+    "test": "jest --env=jsdom --silent -ci --testResultsProcessor=jest-junit",
     "test:watch": "jest --env=jsdom --watch"
   },
   "repository": {

--- a/RetrospectiveExtension.Frontend/package.json
+++ b/RetrospectiveExtension.Frontend/package.json
@@ -59,6 +59,7 @@
     "@types/uuid": "8.3.4",
     "@typescript-eslint/eslint-plugin": "5.9.1",
     "@typescript-eslint/parser": "5.9.1",
+    "@wojtekmaj/enzyme-adapter-react-17": "^0.6.6",
     "crypto-browserify": "3.12.0",
     "css-loader": "6.5.1",
     "enzyme": "^3.11.0",

--- a/RetrospectiveExtension.Frontend/package.json
+++ b/RetrospectiveExtension.Frontend/package.json
@@ -12,7 +12,7 @@
     "publish:d": "npm run build && npm run pack:d && tfx extension publish --manifests vss-extension-dev.json --vsix ./dist/*.vsix",
     "publish:p": "npm run build && npm run pack:p && tfx extension publish --manifests vss-extension-prod.json --vsix ./dist/*.vsix",
     "start:dev": "webpack-dev-server --mode development",
-    "test": "jest --env=jsdom --silent -ci --testResultsProcessor=jest-junit",
+    "test": "jest --env=jsdom --silent -ci --coverage --testResultsProcessor=jest-junit",
     "test:watch": "jest --env=jsdom --watch"
   },
   "repository": {

--- a/RetrospectiveExtension.Frontend/package.json
+++ b/RetrospectiveExtension.Frontend/package.json
@@ -12,7 +12,7 @@
     "publish:d": "npm run build && npm run pack:d && tfx extension publish --manifests vss-extension-dev.json --vsix ./dist/*.vsix",
     "publish:p": "npm run build && npm run pack:p && tfx extension publish --manifests vss-extension-prod.json --vsix ./dist/*.vsix",
     "start:dev": "webpack-dev-server --mode development",
-    "test": "jest --env=jsdom -ci --coverage --testResultsProcessor=jest-junit",
+    "test": "jest --env=jsdom --silent -ci --coverage --testResultsProcessor=jest-junit",
     "test:watch": "jest --env=jsdom --watch"
   },
   "repository": {


### PR DESCRIPTION
**Task**:
https://dev.azure.com/csebostoncrew/Retrospectives-AzDO-Extension/_workitems/edit/1469

**Notes**:
- Phong noted on my last PR that the `__mocks__` were not properly formatted so I have reformatted them in this PR. 
- In my investigations to determine if we can add more sophisticated tests beyond basic rendering / snapshot testing, I have discovered that there is a [known issue with the current enzyme adapter](https://github.com/enzymejs/enzyme/issues/2429), as it does not work with React 17 + the `mount` function. The `mount` function will be necessary for verifying when state changes change the state of children that are nested one or two levels within the component, as the `shallow` function only renders basic children of the component. I have updated to the most popular enzyme adapter with React 17 support, and have verified that it resolves the errors from the React 16 adapter. 
- The ` --coverage` auto generates test coverage reports in the coverage folder, with a summary which looks like the below image. We should determine if we want to add the cobertura coverage file to the Github Actions. 

![image](https://user-images.githubusercontent.com/38594207/153299995-e36acf41-06ea-473c-a4bf-fbb295ea6301.png)
