### PR TITLE
[1499] Update node to v16

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update \
     && apt-get install -y dotnet-sdk-5.0 \
     #
     # Install node
-    && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+    && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
     && apt install -y nodejs \
     #
     # Install npm-check-updates tool globally

--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -21,6 +21,11 @@ jobs:
       - uses: actions/checkout@v2
         name: Check out repository
 
+      - uses: actions/setup-node@v2
+        name: Setup node
+        with:
+          node-version: '16'
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:


### PR DESCRIPTION
- Update Dockerfile to use node v16
- Update ci_frontend.yml to use the setup-node@v2 action to install node v16
- Note that doc changes to specify node v16 will be made in a future doc specific improvement PR