### PR TITLE
fix build failure on merge

### DIFF
--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         working-directory: 'RetrospectiveExtension.Frontend'
 
-      - if: steps.changes.outputs.src == 'true' && github.event_name != 'pull_request'
+      - if: steps.changes.outputs.src == 'true'
         name: Upload test report
         uses: dorny/test-reporter@v1.5.0
         with:

--- a/.github/workflows/ci_frontend.yml
+++ b/.github/workflows/ci_frontend.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash
         working-directory: 'RetrospectiveExtension.Frontend'
 
-      - if: steps.changes.outputs.src == 'true'
+      - if: steps.changes.outputs.src == 'true' && github.event_name != 'pull_request'
         name: Upload test report
         uses: dorny/test-reporter@v1.5.0
         with:
@@ -72,7 +72,7 @@ jobs:
           # process.env.BRANCH = 'pull_27';
           echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
 
-      - if: steps.changes.outputs.src == 'true'
+      - if: steps.changes.outputs.src == 'true' && github.event_name != 'pull_request'
         name: Create the Badge
         uses: schneegans/dynamic-badges-action@v1.0.0
         with:
@@ -84,7 +84,7 @@ jobs:
           color: green
           namedLogo: jest
         
-      - if: steps.changes.outputs.src == 'true'
+      - if: steps.changes.outputs.src == 'true' && github.event_name != 'pull_request'
         name: Test Coverage PR comment
         uses: thollander/actions-comment-pull-request@v1
         with:


### PR DESCRIPTION
The CI fails on code merge, hence we need to add a check to disable code coverage when the code is merged into master.
The Master branch receives code from a different workflow